### PR TITLE
Add MEXC API scraper

### DIFF
--- a/tools/extraction/mexc/README.md
+++ b/tools/extraction/mexc/README.md
@@ -1,0 +1,80 @@
+# MEXC API Documentation Scraper
+
+This tool scrapes the MEXC API documentation and converts it into a single markdown file. The documentation is split into different sections for public and private websocket and REST API data.
+
+## Installation
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/rosssaunders/coincise.git
+   cd coincise/tools/extraction/mexc
+   ```
+
+2. Install dependencies:
+   ```sh
+   npm install
+   ```
+
+## Usage
+
+### Scrape API Documentation
+
+To scrape the MEXC API documentation and save it to a markdown file, use the following command:
+```sh
+node index.js scrape <url> <output-file>
+```
+- `<url>`: The URL of the MEXC API documentation page to scrape.
+- `<output-file>`: The path to the output markdown file.
+
+Example:
+```sh
+node index.js scrape https://mexcdevelop.github.io/apidocs/spot_v3_en/ output.md
+```
+
+### Convert Authentication HTML to Markdown
+
+To convert the authentication section HTML to a markdown table, use the following command:
+```sh
+node index.js convert-auth <input-file> [output-file]
+```
+- `<input-file>`: The path to the input HTML file containing the authentication section.
+- `[output-file]` (optional): The path to the output markdown file. If not provided, the markdown table will be printed to the console.
+
+Example:
+```sh
+node index.js convert-auth auth.html auth.md
+```
+
+### Convert Request Parameters HTML to Markdown
+
+To convert the request parameters section HTML to a markdown table, use the following command:
+```sh
+node index.js convert-params <input-file> [output-file]
+```
+- `<input-file>`: The path to the input HTML file containing the request parameters section.
+- `[output-file]` (optional): The path to the output markdown file. If not provided, the markdown table will be printed to the console.
+
+Example:
+```sh
+node index.js convert-params params.html params.md
+```
+
+## Configuration
+
+The tool uses configuration files to define the URLs for different sections of the MEXC API documentation. The configuration files are located in the `tools/extraction/mexc` directory.
+
+### Public REST API
+
+The `public_rest_api.json` file contains the URLs for the public REST API endpoints. The output directory and combined filename are also defined in this file.
+
+### Private REST API
+
+The `private_rest_api.json` file contains the URLs for the private REST API endpoints. The output directory and combined filename are also defined in this file.
+
+### Public Websocket API
+
+The `public_websocket_api.json` file contains the URLs for the public websocket API endpoints. The output directory and combined filename are also defined in this file.
+
+### Private Websocket API
+
+The `private_websocket_api.json` file contains the URLs for the private websocket API endpoints. The output directory and combined filename are also defined in this file.

--- a/tools/extraction/mexc/extractors.js
+++ b/tools/extraction/mexc/extractors.js
@@ -1,0 +1,237 @@
+const puppeteer = require('puppeteer');
+
+/**
+ * Extract article content from the page
+ * @param {Page} page - Puppeteer page object
+ * @param {Object} options - Options for extraction
+ * @param {boolean} options.html - Whether to return HTML instead of text
+ * @returns {Promise<string>} - Article content as text or HTML
+ */
+const extractArticleContent = async (page, options = {}) => {
+  return await page.evaluate((returnHtml) => {
+    const article = document.querySelector('article');
+    if (!article) return 'Article content not available';
+    
+    if (returnHtml) {
+      // Create a clone to avoid modifying the actual DOM
+      const clone = article.cloneNode(true);
+      
+      // Remove all hash links
+      const hashLinks = clone.querySelectorAll('.hashLink_R2Yq');
+      hashLinks.forEach(link => link.remove());
+      
+      // Remove authentication section (already extracted by extractAuthSection)
+      const authSection = clone.querySelector('#authorization');
+      if (authSection) {
+        authSection.remove();
+      }
+      
+      // Remove query parameters section (already extracted by extractQueryParams)
+      const pathParamsSections = clone.querySelectorAll('#path-params');
+      pathParamsSections.forEach(section => {
+        section.remove();
+      });
+      
+      // Remove request parameters section (already extracted by extractRequestParams)
+      const bodyParamsHeadings = Array.from(clone.querySelectorAll('h3')).filter(h => 
+        h.textContent.trim() === 'Body params');
+      
+      if (bodyParamsHeadings.length > 0) {
+        const section = bodyParamsHeadings[0].closest('[data-testid="content-section"]');
+        if (section) {
+          section.remove();
+        }
+      }
+      
+      // Remove responses section
+      const responseHeadings = Array.from(clone.querySelectorAll('h3')).filter(h => 
+        h.textContent.trim() === 'Responses');
+      
+      if (responseHeadings.length > 0) {
+        const section = responseHeadings[0].closest('[data-testid="content-section"]');
+        if (section) {
+          section.remove();
+        }
+      }
+      
+      return clone.outerHTML;
+    } else {
+      return article.innerText;
+    }
+  }, options.html);
+};
+
+/**
+ * Extract authentication section HTML
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<string|null>} - HTML content or null
+ */
+const extractAuthSection = async (page) => {
+  return await page.evaluate(() => {
+    const authSection = document.querySelector('#authorization');
+    return authSection ? authSection.outerHTML : null;
+  });
+};
+
+/**
+ * Extract request parameters section HTML
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<string|null>} - HTML content or null
+ */
+const extractRequestParams = async (page) => {
+  return await page.evaluate(() => {
+    // Look for the section with "Body params" heading
+    const bodyParamsHeadings = Array.from(document.querySelectorAll('h3')).filter(h => 
+      h.textContent.trim() === 'Body params');
+    
+    if (bodyParamsHeadings.length > 0) {
+      // Get the parent section that contains the params
+      const section = bodyParamsHeadings[0].closest('[data-testid="content-section"]');
+      return section ? section.outerHTML : null;
+    }
+    return null;
+  });
+};
+
+/**
+ * Extract path and query parameters sections HTML
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<Object>} - Object with pathParams and queryParams HTML
+ */
+const extractPathAndQueryParams = async (page) => {
+  return await page.evaluate(() => {
+    const result = {
+      pathParams: null,
+      queryParams: null
+    };
+    
+    // Look for all path-params sections
+    const paramSections = document.querySelectorAll('#path-params');
+    
+    paramSections.forEach(section => {
+      // Check the heading to determine if it's path params or query params
+      const heading = section.querySelector('h3');
+      if (heading) {
+        const headingText = heading.textContent.trim();
+        
+        if (headingText === 'Path Params') {
+          result.pathParams = section.outerHTML;
+        } else if (headingText === 'Query Params') {
+          result.queryParams = section.outerHTML;
+        }
+      }
+    });
+    
+    return result;
+  });
+};
+
+/**
+ * Extract modal content for a specific response button
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<Object>} - Structured modal content
+ */
+const extractModalContent = async (page) => {
+  return await page.evaluate(() => {
+    // Try to extract structured data from the Mui paper component
+    const muiPaper = document.querySelector('.MuiPaper-root');
+    
+    if (muiPaper) {
+      // Get the schema type from the header
+      const schemaType = muiPaper.querySelector('.MuiCardHeader-content .MuiTypography-root span')?.textContent || '';
+      
+      // Extract all properties
+      const properties = [];
+      const listItems = muiPaper.querySelectorAll('.listItem_mkJa');
+      
+      listItems.forEach(item => {
+        const nameElement = item.querySelector('.paramName__NgG');
+        const typeElement = item.querySelector('.paramType_KuQf');
+        const descriptionElement = item.querySelector('.propertyContent_FDlX');
+        
+        // Get property description (text that's not in the header)
+        let description = '';
+        if (descriptionElement) {
+          const descText = descriptionElement.textContent;
+          const headerText = descriptionElement.querySelector('.paramHeader_i_6k')?.textContent || '';
+          description = descText.replace(headerText, '').trim();
+        }
+        
+        if (nameElement && typeElement) {
+          properties.push({
+            name: nameElement.textContent,
+            type: typeElement.textContent,
+            description: description
+          });
+        }
+      });
+      
+      return {
+        schemaType,
+        properties
+      };
+    }
+    
+    return { error: 'Modal content not found' };
+  });
+};
+
+/**
+ * Extract public websocket data
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<string>} - Public websocket data as text
+ */
+const extractPublicWebsocketData = async (page) => {
+  return await page.evaluate(() => {
+    const section = document.querySelector('#public-websocket-endpoints');
+    return section ? section.innerText : 'Public websocket data not available';
+  });
+};
+
+/**
+ * Extract private websocket data
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<string>} - Private websocket data as text
+ */
+const extractPrivateWebsocketData = async (page) => {
+  return await page.evaluate(() => {
+    const section = document.querySelector('#private-websocket-endpoints');
+    return section ? section.innerText : 'Private websocket data not available';
+  });
+};
+
+/**
+ * Extract public REST API data
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<string>} - Public REST API data as text
+ */
+const extractPublicRestApiData = async (page) => {
+  return await page.evaluate(() => {
+    const section = document.querySelector('#public-endpoints');
+    return section ? section.innerText : 'Public REST API data not available';
+  });
+};
+
+/**
+ * Extract private REST API data
+ * @param {Page} page - Puppeteer page object
+ * @returns {Promise<string>} - Private REST API data as text
+ */
+const extractPrivateRestApiData = async (page) => {
+  return await page.evaluate(() => {
+    const section = document.querySelector('#private-endpoints');
+    return section ? section.innerText : 'Private REST API data not available';
+  });
+};
+
+module.exports = {
+  extractArticleContent,
+  extractAuthSection,
+  extractRequestParams,
+  extractModalContent,
+  extractPathAndQueryParams,
+  extractPublicWebsocketData,
+  extractPrivateWebsocketData,
+  extractPublicRestApiData,
+  extractPrivateRestApiData
+};

--- a/tools/extraction/mexc/formatters.js
+++ b/tools/extraction/mexc/formatters.js
@@ -1,0 +1,310 @@
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
+const TurndownService = require('turndown');
+
+/**
+ * Process authentication HTML to markdown table
+ * @param {string} authHtml - HTML content of auth section
+ * @returns {string|null} - Markdown table or null
+ */
+const processAuthSection = (authHtml) => {
+  if (!authHtml) return null;
+  
+  const dom = new JSDOM(authHtml);
+  const document = dom.window.document;
+  
+  // Find all auth items
+  const authItems = document.querySelectorAll('.authItem_haxh');
+  
+  if (authItems.length === 0) return null;
+  
+  // Create the markdown table
+  let markdownTable = `
+## Authentication
+
+| Parameter | Type | Required |
+| --------- | ---- | -------- |
+`;
+  
+  // Process each auth item
+  authItems.forEach(item => {
+    const paramName = item.querySelector('label')?.textContent.trim() || '';
+    const paramType = item.querySelector('.authType_Ecpv')?.textContent.trim() || '';
+    const required = item.querySelector('.authRequired_AspY')?.textContent.trim() || '';
+    
+    markdownTable += `| ${paramName} | ${paramType} | ${required} |\n`;
+  });
+  
+  return markdownTable;
+};
+
+/**
+ * Process request parameters HTML to markdown table
+ * @param {string} paramsHtml - HTML content of request params section
+ * @returns {string|null} - Markdown table or null
+ */
+const processRequestParams = (paramsHtml) => {
+  if (!paramsHtml) return null;
+  
+  const dom = new JSDOM(paramsHtml);
+  const document = dom.window.document;
+  
+  // First determine if this is for query params or body params or path params
+  const sectionTitle = document.querySelector('h3')?.textContent.trim();
+  const isQueryParams = sectionTitle === 'Query Params';
+  const isPathParams = sectionTitle === 'Path Params';
+  const isBodyParams = sectionTitle === 'Body params';
+  
+  // Find all param items
+  // Support both paramItem_Izrs (newer UI) and listItem_mkJa (older UI)
+  const paramItems = document.querySelectorAll('.paramItem_Izrs, .listItem_mkJa');
+  
+  if (paramItems.length === 0) return null;
+  
+  // Create the markdown table with appropriate title
+  let markdownTable = `
+## ${isPathParams ? 'Path Parameters' : isQueryParams ? 'Query Parameters' : 'Request Parameters'}
+
+| Parameter | Type | ${isQueryParams || isPathParams ? 'Required | ' : ''}Description |
+| --------- | ---- | ${isQueryParams || isPathParams ? '-------- | ' : ''}----------- |
+`;
+  
+  // Process each param item
+  paramItems.forEach(item => {
+    // Support both newer and older UI class names
+    const paramName = item.querySelector('.paramName_MlmJ, .paramName__NgG')?.textContent.trim() || '';
+    const paramType = item.querySelector('.paramType_HWMI, .paramType_KuQf')?.textContent.trim() || '';
+    const isRequired = item.querySelector('.paramRequired_Dtof') !== null ? 'Yes' : 'No';
+    
+    // Get description from paragraph
+    let description = '';
+    const paragraph = item.querySelector('.paragraph_nrmP');
+    const possibleValues = item.querySelector('.possibleValues_iyE0');
+    
+    if (paragraph) {
+      // Extract description and handle code tags
+      description = paragraph.innerHTML
+        .replace(/<code>(.*?)<\/code>/g, '`$1`')
+        .replace(/<\/?[^>]+(>|$)/g, ''); // Remove other HTML tags
+    } else if (possibleValues) {
+      description = possibleValues.textContent.trim();
+    }
+    
+    // Escape pipe characters in markdown table
+    const escapedName = paramName.replace(/\|/g, '\\|');
+    const escapedType = paramType.replace(/\|/g, '\\|');
+    const escapedDesc = description.replace(/\|/g, '\\|');
+    
+    if (isQueryParams || isPathParams) {
+      markdownTable += `| ${escapedName} | ${escapedType} | ${isRequired} | ${escapedDesc} |\n`;
+    } else {
+      markdownTable += `| ${escapedName} | ${escapedType} | ${escapedDesc} |\n`;
+    }
+  });
+  
+  return markdownTable;
+};
+
+/**
+ * Generate markdown for API response details
+ * @param {Array} modalResults - Array of response modal results
+ * @returns {string} - Markdown content
+ */
+const generateResponseMarkdown = (modalResults) => {
+  if (!modalResults || modalResults.length === 0) {
+    return '';
+  }
+  
+  let markdown = '## API Response Details\n\n';
+  
+  modalResults.forEach(result => {
+    if (!result.buttonText || !result.modalContent || !result.modalContent.properties) {
+      return;
+    }
+    
+    // Ensure proper spacing between HTTP status code and description
+    // Extract and format HTTP status code and description
+    // This handles cases like "401Unauthorized" or "200OK" and formats to "401 Unauthorized"
+    let formattedButtonText = result.buttonText;
+    
+    // First clean up the text (remove any extraneous content)
+    formattedButtonText = formattedButtonText.replace(/OpenInFull|[\r\n]+/g, '').trim();
+    
+    // Format HTTP status codes - handle various patterns
+    // 1. Match digit sequence followed by uppercase letter and insert space
+    formattedButtonText = formattedButtonText.replace(/(\d+)([A-Z][a-z])/g, '$1 $2');
+    
+    // 2. Match digit sequence followed immediately by any letter (catches additional cases)
+    formattedButtonText = formattedButtonText.replace(/(\d+)([a-zA-Z])/g, '$1 $2');
+    
+    markdown += `### Response: ${formattedButtonText}\n\n`;
+    markdown += '| Property | Type | Description |\n';
+    markdown += '| -------- | ---- | ----------- |\n';
+    
+    result.modalContent.properties.forEach(prop => {
+      // Escape pipe characters in markdown table
+      const escapedName = prop.name.replace(/\|/g, '\\|');
+      const escapedType = prop.type.replace(/\|/g, '\\|');
+      const escapedDesc = prop.description.replace(/\|/g, '\\|');
+      
+      markdown += `| ${escapedName} | ${escapedType} | ${escapedDesc} |\n`;
+    });
+    
+    markdown += '\n';
+  });
+  
+  return markdown;
+};
+
+/**
+ * Generate the complete markdown document
+ * @param {string} articleContent - Content from the article section
+ * @param {Array} modalResults - Array of response modal results
+ * @param {string} authMarkdown - Authentication markdown
+ * @param {string} requestParamsMarkdown - Request parameters markdown
+ * @param {string} pathParamsMarkdown - Path parameters markdown
+ * @param {string} queryParamsMarkdown - Query parameters markdown
+ * @param {string} publicWebsocketMarkdown - Public websocket markdown
+ * @param {string} privateWebsocketMarkdown - Private websocket markdown
+ * @param {string} publicRestApiMarkdown - Public REST API markdown
+ * @param {string} privateRestApiMarkdown - Private REST API markdown
+ * @returns {string} - Complete markdown document
+ */
+const generateMarkdownDocument = (articleContent, modalResults, authMarkdown = '', requestParamsMarkdown = '', pathParamsMarkdown = '', queryParamsMarkdown = '', publicWebsocketMarkdown = '', privateWebsocketMarkdown = '', publicRestApiMarkdown = '', privateRestApiMarkdown = '') => {
+  return `
+${articleContent}
+
+${authMarkdown || ''}
+
+${pathParamsMarkdown || ''}
+
+${queryParamsMarkdown || ''}
+
+${requestParamsMarkdown || ''}
+
+${publicWebsocketMarkdown || ''}
+
+${privateWebsocketMarkdown || ''}
+
+${publicRestApiMarkdown || ''}
+
+${privateRestApiMarkdown || ''}
+
+${generateResponseMarkdown(modalResults)}
+`.trim();
+};
+
+/**
+ * Convert HTML content to Markdown
+ * @param {string} html - HTML content to convert
+ * @returns {string} - Converted Markdown
+ */
+const convertHtmlToMarkdown = (html) => {
+  const turndownService = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced'
+  });
+  
+  // Add custom rule for code tags
+  turndownService.addRule('code', {
+    filter: 'code',
+    replacement: function(content) {
+      return '`' + content + '`';
+    }
+  });
+  
+  // Add a custom table processing rule that handles complex nested tables
+  turndownService.addRule('table', {
+    filter: 'table',
+    replacement: function(content, node, options) {
+      // Extract table HTML
+      const tableHtml = node.outerHTML;
+      
+      // Use regex to extract table data instead of DOM manipulation
+      // which can be tricky across Node.js and browser environments
+      
+      // First, try to detect table headers
+      let tableMarkdown = '';
+      let headers = [];
+      
+      // Look for th elements to build header row
+      const thRegex = /<th[^>]*>([\s\S]*?)<\/th>/gi;
+      let thMatch;
+      while ((thMatch = thRegex.exec(tableHtml)) !== null) {
+        // Clean up the content (remove nested divs, etc.)
+        let headerContent = thMatch[1]
+          .replace(/<div[^>]*>([\s\S]*?)<\/div>/g, '$1')
+          .replace(/<[^>]+>/g, '')
+          .trim();
+        headers.push(headerContent);
+      }
+      
+      // If we found headers, create the header row
+      if (headers.length > 0) {
+        tableMarkdown += '| ' + headers.join(' | ') + ' |\n';
+        tableMarkdown += '| ' + headers.map(() => '---').join(' | ') + ' |\n';
+      }
+      
+      // Now extract the table rows using tr and td elements
+      const trRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+      let trMatch;
+      
+      while ((trMatch = trRegex.exec(tableHtml)) !== null) {
+        // Skip header rows (already processed)
+        if (trMatch[1].includes('<th')) continue;
+        
+        // Process td elements in this row
+        const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+        let cells = [];
+        let tdMatch;
+        
+        while ((tdMatch = tdRegex.exec(trMatch[1])) !== null) {
+          // Process cell content
+          let cellContent = tdMatch[1];
+          
+          // Handle code tags
+          cellContent = cellContent.replace(/<code>(.*?)<\/code>/g, '`$1`');
+          
+          // Handle links
+          cellContent = cellContent.replace(
+            /<a\s+href="([^"]+)"[^>]*>(.*?)<\/a>/g, 
+            '[$2]($1)'
+          );
+          
+          // Clean up remaining HTML and trim
+          cellContent = cellContent
+            .replace(/<div[^>]*>([\s\S]*?)<\/div>/g, '$1')
+            .replace(/<[^>]+>/g, '')
+            .trim();
+          
+          cells.push(cellContent);
+        }
+        
+        // Only add non-empty rows
+        if (cells.length > 0) {
+          tableMarkdown += '| ' + cells.join(' | ') + ' |\n';
+        }
+      }
+      
+      return '\n\n' + tableMarkdown + '\n';
+    }
+  });
+  
+  // Remove default table rules to avoid conflicts
+  if (turndownService.rules.tableCell) {
+    turndownService.remove('tableCell');
+  }
+  if (turndownService.rules.tableRow) {
+    turndownService.remove('tableRow');
+  }
+  
+  return turndownService.turndown(html);
+};
+
+module.exports = {
+  processAuthSection,
+  processRequestParams,
+  generateResponseMarkdown,
+  generateMarkdownDocument,
+  convertHtmlToMarkdown
+};

--- a/tools/extraction/mexc/index.js
+++ b/tools/extraction/mexc/index.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { scrapeApiDocumentation } = require('./scraper');
+const { processAuthSection, processRequestParams } = require('./formatters');
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const command = args[0];
+
+// Print help information
+const printHelp = () => {
+  console.log(`
+MEXC API Documentation Scraper
+
+Usage:
+  node index.js scrape <url> <output-file>     # Scrape API docs from URL to markdown file
+  node index.js convert-auth <input-file> [output-file]     # Convert auth HTML to markdown
+  node index.js convert-params <input-file> [output-file]   # Convert request params HTML to markdown
+  node index.js help                           # Show this help message
+  `);
+};
+
+// Main function to handle CLI commands
+const main = async () => {
+  try {
+    if (!command || command === 'help' || command === '--help' || command === '-h') {
+      printHelp();
+      return;
+    }
+    
+    if (command === 'scrape') {
+      const url = args[1];
+      const outputFile = args[2];
+      
+      if (!url || !outputFile) {
+        console.error('Error: URL and output file are required');
+        printHelp();
+        return;
+      }
+      
+      await scrapeApiDocumentation(url, outputFile);
+    } 
+    else if (command === 'convert-auth' && args[1]) {
+      try {
+        // Install jsdom if not already installed
+        try {
+          require('jsdom');
+        } catch (e) {
+          console.log('Installing jsdom...');
+          const { execSync } = require('child_process');
+          execSync('npm install jsdom');
+        }
+        
+        const inputFile = args[1];
+        const outputFile = args[2];
+        
+        console.log(`Reading auth HTML from ${inputFile}...`);
+        const htmlContent = fs.readFileSync(inputFile, 'utf8');
+        const markdownTable = processAuthSection(htmlContent);
+        
+        if (!markdownTable) {
+          console.error('Error: Could not extract authentication data from input file');
+          return;
+        }
+        
+        console.log(markdownTable);
+        
+        // Optionally save to an output file if specified
+        if (outputFile) {
+          fs.writeFileSync(outputFile, markdownTable);
+          console.log(`Markdown table written to ${outputFile}`);
+        }
+      } catch (error) {
+        console.error('Error converting auth file:', error.message);
+      }
+    } 
+    else if (command === 'convert-params' && args[1]) {
+      try {
+        // Install jsdom if not already installed
+        try {
+          require('jsdom');
+        } catch (e) {
+          console.log('Installing jsdom...');
+          const { execSync } = require('child_process');
+          execSync('npm install jsdom');
+        }
+        
+        const inputFile = args[1];
+        const outputFile = args[2];
+        
+        console.log(`Reading params HTML from ${inputFile}...`);
+        const htmlContent = fs.readFileSync(inputFile, 'utf8');
+        const markdownTable = processRequestParams(htmlContent);
+        
+        if (!markdownTable) {
+          console.error('Error: Could not extract request parameters from input file');
+          return;
+        }
+        
+        console.log(markdownTable);
+        
+        // Optionally save to an output file if specified
+        if (outputFile) {
+          fs.writeFileSync(outputFile, markdownTable);
+          console.log(`Markdown table written to ${outputFile}`);
+        }
+      } catch (error) {
+        console.error('Error converting params file:', error.message);
+      }
+    }
+    else {
+      console.error(`Unknown command: ${command}`);
+      printHelp();
+    }
+  } catch (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+};
+
+// Run the main function
+main().catch(error => {
+  console.error('Unhandled error:', error);
+  process.exit(1);
+});
+
+// If this file is being executed directly
+if (require.main === module) {
+  // Make CLI executable
+}
+
+// Export the main functionality for use as a module
+module.exports = {
+  scrapeApiDocumentation
+};

--- a/tools/extraction/mexc/package.json
+++ b/tools/extraction/mexc/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mexc-api-scraper",
+  "version": "1.0.0",
+  "description": "Scraper for MEXC API documentation with markdown output",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "scrape": "node index.js scrape",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "mexc",
+    "api",
+    "documentation",
+    "scraper",
+    "markdown"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "puppeteer": "^24.4.0",
+    "turndown": "^7.0.0",
+    "jsdom": "^26.0.0"
+  },
+  "bin": {
+    "mexc-scraper": "./index.js"
+  }
+}

--- a/tools/extraction/mexc/private_rest_api.json
+++ b/tools/extraction/mexc/private_rest_api.json
@@ -1,0 +1,22 @@
+{
+  "output_directory": "../../../../docs/mexc",
+  "combined_filename": "private_rest_api.md",
+  "urls": [
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#private-endpoints",
+      "filename": "private_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#account-endpoints",
+      "filename": "account_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#order-endpoints",
+      "filename": "order_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#wallet-endpoints",
+      "filename": "wallet_endpoints.md"
+    }
+  ]
+}

--- a/tools/extraction/mexc/private_websocket_api.json
+++ b/tools/extraction/mexc/private_websocket_api.json
@@ -1,0 +1,18 @@
+{
+  "output_directory": "../../../../docs/mexc",
+  "combined_filename": "private_websocket_api.md",
+  "urls": [
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#private-websocket-endpoints",
+      "filename": "private_websocket_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#account-websocket-endpoints",
+      "filename": "account_websocket_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#order-websocket-endpoints",
+      "filename": "order_websocket_endpoints.md"
+    }
+  ]
+}

--- a/tools/extraction/mexc/public_rest_api.json
+++ b/tools/extraction/mexc/public_rest_api.json
@@ -1,0 +1,18 @@
+{
+  "output_directory": "../../../../docs/mexc",
+  "combined_filename": "public_rest_api.md",
+  "urls": [
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#public-endpoints",
+      "filename": "public_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#market-endpoints",
+      "filename": "market_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#public-market-data",
+      "filename": "public_market_data.md"
+    }
+  ]
+}

--- a/tools/extraction/mexc/public_websocket_api.json
+++ b/tools/extraction/mexc/public_websocket_api.json
@@ -1,0 +1,18 @@
+{
+  "output_directory": "../../../../docs/mexc",
+  "combined_filename": "public_websocket_api.md",
+  "urls": [
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#public-websocket-endpoints",
+      "filename": "public_websocket_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#market-websocket-endpoints",
+      "filename": "market_websocket_endpoints.md"
+    },
+    {
+      "url": "https://mexcdevelop.github.io/apidocs/spot_v3_en/#ticker-websocket-endpoints",
+      "filename": "ticker_websocket_endpoints.md"
+    }
+  ]
+}


### PR DESCRIPTION
Add tools to scrape and convert MEXC API documentation into markdown format.

* **Extractors**: Implement functions in `tools/extraction/mexc/extractors.js` to extract public and private websocket and REST API data using Puppeteer.
* **Formatters**: Implement functions in `tools/extraction/mexc/formatters.js` to format extracted data into markdown using TurndownService.
* **CLI Commands**: Implement CLI commands in `tools/extraction/mexc/index.js` to scrape, convert, and save MEXC API documentation.
* **Configuration**: Add configuration files (`private_rest_api.json`, `public_rest_api.json`, `private_websocket_api.json`, `public_websocket_api.json`) to list URLs for different API sections and define output directories and filenames.
* **Documentation**: Add `tools/extraction/mexc/README.md` to provide instructions for installation and usage of the scraper tool.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rosssaunders/coincise?shareId=XXXX-XXXX-XXXX-XXXX).