### PR TITLE
Binance Spot API Documentation Update

### DIFF
--- a/docs/binance/spot/private_rest_api.md
+++ b/docs/binance/spot/private_rest_api.md
@@ -3049,12 +3049,12 @@ Retrieves a specific order list based on provided optional parameters.
 
 **Parameters:**
 
-| Name                | Type     | Mandatory | Description                                                    |
-| ------------------- | -------- | --------- | -------------------------------------------------------------- |
-| \-orderListId       | \-LONG   | \-NO      | \-Either `orderListId` or `listClientOrderId` must be provided |
-| \-origClientOrderId | \-STRING | \-NO      | \-Either `orderListId` or `listClientOrderId` must be provided |
-| \-recvWindow        | \-LONG   | \-NO      | \-The value cannot be greater than `60000`                     |
-| \-timestamp         | \-LONG   | \-YES     |                                                                |
+| Name                | Type     | Mandatory | Description                                                                                       |
+| ------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
+| \-orderListId       | \-LONG   | \-NO\*    | \-Query order list by `orderListId`. `orderListId` or `origClientOrderId` must be provided.       |
+| \-origClientOrderId | \-STRING | \-NO\*    | \-Query order list by `listClientOrderId`. `orderListId` or `origClientOrderId` must be provided. |
+| \-recvWindow        | \-LONG   | \-NO      | \-The value cannot be greater than `60000`                                                        |
+| \-timestamp         | \-LONG   | \-YES     |                                                                                                   |
 
 **Data Source:** Database
 

--- a/docs/binance/spot/private_websocket_api.md
+++ b/docs/binance/spot/private_websocket_api.md
@@ -5268,14 +5268,14 @@ For execution status of individual orders, use
 
 **Parameters**:
 
-| Name                  | Type     | Mandatory                           | Description                               |
-| --------------------- | -------- | ----------------------------------- | ----------------------------------------- |
-| \-`origClientOrderId` | \-STRING | \-YES                               | \-Query order list by `listClientOrderId` |
-| \-`orderListId`       | \-INT    | \-Query order list by `orderListId` |
-| \-`apiKey`            | \-STRING | \-YES                               |                                           |
-| \-`recvWindow`        | \-LONG   | \-NO                                | \-The value cannot be greater than 60000  |
-| \-`signature`         | \-STRING | \-YES                               |                                           |
-| \-`timestamp`         | \-LONG   | \-YES                               |                                           |
+| Name                  | Type     | Mandatory                                                                                  | Description                                                                                      |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| \-`origClientOrderId` | \-STRING | \-NO\*                                                                                     | \-Query order list by `listClientOrderId`.`orderListId` or `origClientOrderId` must be provided. |
+| \-`orderListId`       | \-INT    | \-Query order list by `orderListId`.`orderListId` or `origClientOrderId` must be provided. |
+| \-`apiKey`            | \-STRING | \-YES                                                                                      |                                                                                                  |
+| \-`recvWindow`        | \-LONG   | \-NO                                                                                       | \-The value cannot be greater than 60000                                                         |
+| \-`signature`         | \-STRING | \-YES                                                                                      |                                                                                                  |
+| \-`timestamp`         | \-LONG   | \-YES                                                                                      |                                                                                                  |
 
 Notes:
 


### PR DESCRIPTION
This pull request updates the documentation for Binance's Spot Private REST and WebSocket APIs to clarify parameter requirements and improve consistency in descriptions. The changes primarily focus on specifying mandatory fields and refining descriptions for better understanding.

### Documentation Updates:

* **REST API (`docs/binance/spot/private_rest_api.md`)**:
  - Updated the descriptions for `orderListId` and `origClientOrderId` parameters to clarify their usage. Added a note that either `orderListId` or `origClientOrderId` must be provided.

* **WebSocket API (`docs/binance/spot/private_websocket_api.md`)**:
  - Adjusted the mandatory status of `origClientOrderId` to `NO*` and clarified that either `orderListId` or `origClientOrderId` must be provided. Improved parameter descriptions for better alignment with the REST API documentation.