### PR TITLE
OKX API Documentation Update

### DIFF
--- a/docs/okx/private_order_book_trading_rest_api.md
+++ b/docs/okx/private_order_book_trading_rest_api.md
@@ -4,12 +4,12 @@
 
 All private REST requests must contain the following headers:
 
-- `OK-ACCESS-KEY` The API Key as a String.
+- `OK-ACCESS-KEY` The API key as a String.
 - `OK-ACCESS-SIGN` The Base64-encoded signature (see Signing Messages subsection
   for details).
 - `OK-ACCESS-TIMESTAMP` The UTC timestamp of your request .e.g :
   2020-12-08T09:08:57.715Z
-- `OK-ACCESS-PASSPHRASE` The passphrase you specified when creating the APIKey.
+- `OK-ACCESS-PASSPHRASE` The passphrase you specified when creating the API key.
 
 Request bodies should have content type `application/json` and be in valid JSON
 format.
@@ -22,10 +22,10 @@ format.
 
 The `OK-ACCESS-SIGN` header is generated as follows:
 
-- Create a prehash string of timestamp + method + requestPath + body (where +
+- Create a pre-hash string of timestamp + method + requestPath + body (where +
   represents String concatenation).
 - Prepare the SecretKey.
-- Sign the prehash string with the SecretKey using the HMAC SHA256.
+- Sign the pre-hash string with the SecretKey using the HMAC SHA256.
 - Encode the signature in the Base64 format.
 
 Example:
@@ -47,7 +47,7 @@ Example: `{"instId":"BTC-USDT","lever":"5","mgnMode":"isolated"}`
 
 \`GET\` request parameters are counted as requestpath, not body
 
-The SecretKey is generated when you create an APIKey.
+The SecretKey is generated when you create an API key.
 
 Example: `22582BD0CFF14C41EDBF1AB98506286D`
 

--- a/docs/okx/private_order_book_trading_websocket_api.md
+++ b/docs/okx/private_order_book_trading_websocket_api.md
@@ -126,8 +126,8 @@ First concatenate `timestamp`, `method`, `requestPath`, strings, then use HMAC
 SHA256 method to encrypt the concatenated string with SecretKey, and then
 perform Base64 encoding.
 
-**secretKey**: The security key generated when the user applies for APIKey, e.g.
-: 22582BD0CFF14C41EDBF1AB98506286D
+**secretKey**: The security key generated when the user applies for API key,
+e.g. `22582BD0CFF14C41EDBF1AB98506286D`
 
 **Example of timestamp**: const timestamp = '' + Date.now() / 1,000
 
@@ -261,12 +261,8 @@ Error Code from 60000 to 64002
 | 60014      | Requests too frequent                                                                                                                                                                                                                                            |
 | 60018      | Wrong URL or {0} doesn't exist. Please use the correct URL, channel and parameters referring to API document.                                                                                                                                                    |
 | 60019      | Invalid op: {op}                                                                                                                                                                                                                                                 |
-| 60020      | APIKey subscription amount exceeds the limit {0}.                                                                                                                                                                                                                |
-| 60021      | This operation does not support multiple accounts login.                                                                                                                                                                                                         |
-| 60022      | Bulk login partially succeeded                                                                                                                                                                                                                                   |
 | 60023      | Bulk login requests too frequent                                                                                                                                                                                                                                 |
 | 60024      | Wrong passphrase                                                                                                                                                                                                                                                 |
-| 60025      | token subscription amount exceeds the limit {0}                                                                                                                                                                                                                  |
 | 60026      | Batch login by APIKey and token simultaneously is not supported.                                                                                                                                                                                                 |
 | 60027      | Parameter {0} can not be empty.                                                                                                                                                                                                                                  |
 | 60028      | The current operation is not supported by this URL. Please use the correct WebSocket URL for the operation.                                                                                                                                                      |
@@ -279,6 +275,9 @@ Error Code from 60000 to 64002
 | 64001      | This channel has been migrated to the '/business' URL. Please subscribe using the new URL. More details can refer to: https://www.okx.com/help-center/changes-to-v5-api-websocket-subscription-parameter-and-url.                                                |
 | 64002      | This channel is not supported by "/business" URL. Please use "/private" URL(for private channels), or "/public" URL(for public channels). More details can refer to: https://www.okx.com/help-center/changes-to-v5-api-websocket-subscription-parameter-and-url. |
 | 64003      | Your trading fee tier doesn't meet the requirement to access this channel                                                                                                                                                                                        |
+| 64004      | Subscribe to both {channelName} and books-l2-tbt for {instId} is not allowed. Unsubscribe books-l2-tbt first.                                                                                                                                                    |
+| 64007      | Operation {0} failed due to WebSocket internal error. Please try again later.                                                                                                                                                                                    |
+| 64008      | The connection will soon be closed for a service upgrade. Please reconnect.                                                                                                                                                                                      |
 
 #### Close Frame
 

--- a/docs/okx/public_market_data_websocket_api.md
+++ b/docs/okx/public_market_data_websocket_api.md
@@ -126,8 +126,8 @@ First concatenate `timestamp`, `method`, `requestPath`, strings, then use HMAC
 SHA256 method to encrypt the concatenated string with SecretKey, and then
 perform Base64 encoding.
 
-**secretKey**: The security key generated when the user applies for APIKey, e.g.
-: 22582BD0CFF14C41EDBF1AB98506286D
+**secretKey**: The security key generated when the user applies for API key,
+e.g. `22582BD0CFF14C41EDBF1AB98506286D`
 
 **Example of timestamp**: const timestamp = '' + Date.now() / 1,000
 


### PR DESCRIPTION
This pull request includes several updates to the OKX API documentation. The changes focus on improving consistency in terminology, correcting minor formatting issues, and updating error codes for WebSocket APIs. Below is a summary of the most important changes:

### Terminology Consistency:
* Standardized the term "API key" across the documentation by replacing inconsistent variations like "APIKey" and "APIKey subscription" [[1]](diffhunk://#diff-4e5954d594352e0c8bcf46f698bec4c1d092ebdec55c73654d0656072f93335bL7-R12) [[2]](diffhunk://#diff-4e5954d594352e0c8bcf46f698bec4c1d092ebdec55c73654d0656072f93335bL50-R50) [[3]](diffhunk://#diff-0d1dfd6a9241db0d16c83991a177e8676f7961196d11017064cd7de4b0a59bf0L129-R130) [[4]](diffhunk://#diff-7d5e2029b9b02212fb8c6e493b815d33c1e7c0e935cfc90b5bc8c4571ccf7ec8L129-R130).

### Formatting Improvements:
* Corrected the term "prehash" to "pre-hash" for clarity in the signing instructions.
* Enhanced formatting for examples and descriptions, such as enclosing example values in backticks for better readability [[1]](diffhunk://#diff-0d1dfd6a9241db0d16c83991a177e8676f7961196d11017064cd7de4b0a59bf0L129-R130) [[2]](diffhunk://#diff-7d5e2029b9b02212fb8c6e493b815d33c1e7c0e935cfc90b5bc8c4571ccf7ec8L129-R130).

### WebSocket API Error Code Updates:
* Removed outdated error codes (e.g., 60020, 60021, 60022, 60025) and added new ones (e.g., 64004, 64007, 64008) to reflect the latest WebSocket API behavior [[1]](diffhunk://#diff-0d1dfd6a9241db0d16c83991a177e8676f7961196d11017064cd7de4b0a59bf0L264-L269) [[2]](diffhunk://#diff-0d1dfd6a9241db0d16c83991a177e8676f7961196d11017064cd7de4b0a59bf0R278-R280).