### PR TITLE
Bitget API Documentation Update

### DIFF
--- a/docs/bitget/change_log.md
+++ b/docs/bitget/change_log.md
@@ -2,6 +2,13 @@
 
 ## Changelog
 
+### \[May 14, 2025\] New version: Order-taking staff API Key creation interface adds currency pair range description.[​](#may-14-2025-new-version-order-taking-staff-api-key-creation-interface-adds-currency-pair-range-description "Direct link to may-14-2025-new-version-order-taking-staff-api-key-creation-interface-adds-currency-pair-range-description")
+
+Interface：/api/v2/copy/mix-trader/create-copy-api  
+Changes：
+
+- New: Added description for order-taking currency pair range.
+
 ### \[May 09, 2025\] Obtain the adjustment of the input parameters for the current funding rate.[​](#may-09-2025-obtain-the-adjustment-of-the-input-parameters-for-the-current-funding-rate "Direct link to may-09-2025-obtain-the-adjustment-of-the-input-parameters-for-the-current-funding-rate")
 
 Interface：/api/v2/mix/market/current-fund-rate
@@ -72,8 +79,6 @@ Channel
 Changes：
 
 - Add to the push data `utime`
-
-### \[Apr 10, 2025\] Adjustment to virtual sub-account API key related endpoints[​](#apr-10-2025-adjustment-to-virtual-sub-account-api-key-related-endpoints "Direct link to apr-10-2025-adjustment-to-virtual-sub-account-api-key-related-endpoints")
 
 ### \[Apr 30,2025\] For the trading details of the WS futures, push fields are added to the spot/futures depth channels.[​](#apr-302025-for-the-trading-details-of-the-ws-futures-push-fields-are-added-to-the-spotfutures-depth-channels "Direct link to apr-302025-for-the-trading-details-of-the-ws-futures-push-fields-are-added-to-the-spotfutures-depth-channels")
 

--- a/docs/bitget/futures_api.md
+++ b/docs/bitget/futures_api.md
@@ -1995,6 +1995,11 @@ Response
   latest reduce-only order request will not include an `orderId`. You can use
   the `clientOid` set in the request to query order details or retrieve the
   orderId from the current pending orders.
+- For elite traders, please strictly adhere to the list of trading pairs
+  specified in the
+  [Available trading pairs and parameters for elite traders](https://www.bitget.com/zh-CN/support/articles/12560603808895)
+  when placing orders using the Copy Trading API Key. Trading pairs outside the
+  announced list are not available for copy trading.
 
 #### HTTP Request[​](#http-request "Direct link to HTTP Request")
 

--- a/docs/bitget/spot_api.md
+++ b/docs/bitget/spot_api.md
@@ -550,7 +550,11 @@ Rate limit: 1 request/second/UID for **copy trading traders**
 
 #### Description[​](#description "Direct link to Description")
 
-Place Order
+- For elite traders, please strictly adhere to the list of trading pairs
+  specified in the
+  [Available trading pairs and parameters for elite traders](https://www.bitget.com/zh-CN/support/articles/12560603808895)
+  when placing orders using the Copy Trading API Key. Trading pairs outside the
+  announced list are not available for copy trading.
 
 #### HTTP Request[​](#http-request "Direct link to HTTP Request")
 
@@ -2457,7 +2461,7 @@ Frequency limit:10 times/1s (UID)
 
 #### Description[​](#description "Direct link to Description")
 
-Get Deposit Records(Not include Fiat deposit record)
+Get Deposit Records
 
 #### HTTP Request[​](#http-request "Direct link to HTTP Request")
 


### PR DESCRIPTION
This pull request includes updates to the Bitget API documentation, focusing on clarifying trading pair restrictions for elite traders, adding descriptions for new features, and minor content adjustments. Below are the key changes grouped by theme:

### Clarifications for Elite Traders:
* Added a note in `docs/bitget/futures_api.md` specifying that elite traders must adhere to a predefined list of trading pairs when using the Copy Trading API Key. Trading pairs outside this list are not supported.
* Included the same restriction for elite traders in `docs/bitget/spot_api.md` under the "Place Order" section.

### New Feature Descriptions:
* Documented a new feature in `docs/bitget/change_log.md` (May 14, 2025 entry), describing the addition of currency pair range descriptions for the order-taking staff API Key creation interface.

### Minor Adjustments:
* Removed a redundant changelog entry for April 10, 2025, in `docs/bitget/change_log.md`.
* Simplified the description of the "Get Deposit Records" endpoint in `docs/bitget/spot_api.md` by removing a note about excluding fiat deposit records.