### PR TITLE
Deribit API Documentation Update

### DIFF
--- a/docs/deribit/private_account_api.md
+++ b/docs/deribit/private_account_api.md
@@ -1364,7 +1364,7 @@ This is a private method; it can only be used after authentication.
 
 # Rate Limits
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit uses a volume-tiered rate limit system, focusing primarily on matching
 engine requests. These rate limits are implemented to ensure the robustness of
@@ -1549,7 +1549,7 @@ quote_cancel
 
 # Connection Management
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 ## Connection[](#heading-1)
 
@@ -1704,7 +1704,7 @@ false, "post_only": false, "self_trade": false, "contracts": 2505,
 
 # API Usage Policy
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit is committed to providing a fast, reliable, and efficient trading
 platform for all users. To maintain the integrity and performance of our system,

--- a/docs/deribit/private_block_combo_trading_api.md
+++ b/docs/deribit/private_block_combo_trading_api.md
@@ -2710,7 +2710,7 @@ This is a private method; it can only be used after authentication.
 
 # Rate Limits
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit uses a volume-tiered rate limit system, focusing primarily on matching
 engine requests. These rate limits are implemented to ensure the robustness of
@@ -2895,7 +2895,7 @@ quote_cancel
 
 # Connection Management
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 ## Connection[](#heading-1)
 
@@ -2983,7 +2983,7 @@ when logging out, they can override this setting with `Tag 9003.`
 
 # API Usage Policy
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit is committed to providing a fast, reliable, and efficient trading
 platform for all users. To maintain the integrity and performance of our system,

--- a/docs/deribit/private_trading_api.md
+++ b/docs/deribit/private_trading_api.md
@@ -3371,7 +3371,7 @@ This is a private method; it can only be used after authentication.
 
 # Rate Limits
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit uses a volume-tiered rate limit system, focusing primarily on matching
 engine requests. These rate limits are implemented to ensure the robustness of
@@ -3556,7 +3556,7 @@ quote_cancel
 
 # Connection Management
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 ## Connection[](#heading-1)
 
@@ -3711,7 +3711,7 @@ false, "post_only": false, "self_trade": false, "contracts": 2505,
 
 # API Usage Policy
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit is committed to providing a fast, reliable, and efficient trading
 platform for all users. To maintain the integrity and performance of our system,

--- a/docs/deribit/public_api.md
+++ b/docs/deribit/public_api.md
@@ -899,7 +899,7 @@ _This method takes no parameters_
 
 # Rate Limits
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit uses a volume-tiered rate limit system, focusing primarily on matching
 engine requests. These rate limits are implemented to ensure the robustness of
@@ -1084,7 +1084,7 @@ quote_cancel
 
 # Connection Management
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 ## Connection[](#heading-1)
 
@@ -1172,7 +1172,7 @@ when logging out, they can override this setting with `Tag 9003.`
 
 # API Usage Policy
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 Deribit is committed to providing a fast, reliable, and efficient trading
 platform for all users. To maintain the integrity and performance of our system,
@@ -1296,7 +1296,7 @@ reach out to our support team.
 
 # Server Infrastructure
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 ## Server Infrastructure[](#heading-1)
 
@@ -1412,7 +1412,7 @@ LD4:01:00S14 – Equinix LD4, 2 Buckingham Avenue, Slough, SL1 4NB, UK
 
 # Asia Gateway
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 To offer faster access to the Deribit platform for clients located in Asia, we
 offer a gateway connecting to Deribit from Hong Kong.
@@ -1431,7 +1431,7 @@ Please use [asia.deribit.com](http://asia.deribit.com) to access the gateway.
 
 # Deribit AWS Endpoint Service instruction
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 In order to offer its customers residing in AWS a direct connection to its
 backend systems, Deribit has created an AWS Endpoint Service for customers to
@@ -1616,7 +1616,7 @@ for you.
 
 # Deribit AWS Multicast Service Instruction
 
-- Updated 1 month ago
+- Updated 2 months ago
 
 ## Introduction[](#heading-1)
 


### PR DESCRIPTION
This pull request updates the documentation across multiple API files to reflect that the last update occurred "2 months ago" instead of "1 month ago." These changes are consistent across all sections of the documentation and do not introduce new functionality or content.

### Documentation Updates:

* Updated the "last updated" timestamp across all sections in the following files:
  - `docs/deribit/private_account_api.md` [[1]](diffhunk://#diff-03790685891c1b656990f5530ccb98d331686988867b08b64a1b5a9b78c6a6c6L1367-R1367) [[2]](diffhunk://#diff-03790685891c1b656990f5530ccb98d331686988867b08b64a1b5a9b78c6a6c6L1552-R1552) [[3]](diffhunk://#diff-03790685891c1b656990f5530ccb98d331686988867b08b64a1b5a9b78c6a6c6L1707-R1707)
  - `docs/deribit/private_block_combo_trading_api.md` [[1]](diffhunk://#diff-ae844f5a817b9c95ac5b54e1c793636257ab4b8135d318bfbd19aa9fa2d34489L2713-R2713) [[2]](diffhunk://#diff-ae844f5a817b9c95ac5b54e1c793636257ab4b8135d318bfbd19aa9fa2d34489L2898-R2898) [[3]](diffhunk://#diff-ae844f5a817b9c95ac5b54e1c793636257ab4b8135d318bfbd19aa9fa2d34489L2986-R2986)
  - `docs/deribit/private_trading_api.md` [[1]](diffhunk://#diff-b4b13db5de20ec13d6aa4e42c502924247d8cfdc7e6f5bdced9ee70229daa2dbL3374-R3374) [[2]](diffhunk://#diff-b4b13db5de20ec13d6aa4e42c502924247d8cfdc7e6f5bdced9ee70229daa2dbL3559-R3559) [[3]](diffhunk://#diff-b4b13db5de20ec13d6aa4e42c502924247d8cfdc7e6f5bdced9ee70229daa2dbL3714-R3714)
  - `docs/deribit/public_api.md` [[1]](diffhunk://#diff-1d410da5e0d716a6ce23d4b53049d7edf4c5840dfd3868f25771e1d14f616e23L902-R902) [[2]](diffhunk://#diff-1d410da5e0d716a6ce23d4b53049d7edf4c5840dfd3868f25771e1d14f616e23L1087-R1087) [[3]](diffhunk://#diff-1d410da5e0d716a6ce23d4b53049d7edf4c5840dfd3868f25771e1d14f616e23L1175-R1175) [[4]](diffhunk://#diff-1d410da5e0d716a6ce23d4b53049d7edf4c5840dfd3868f25771e1d14f616e23L1299-R1299) [[5]](diffhunk://#diff-1d410da5e0d716a6ce23d4b53049d7edf4c5840dfd3868f25771e1d14f616e23L1415-R1415) [[6]](diffhunk://#diff-1d410da5e0d716a6ce23d4b53049d7edf4c5840dfd3868f25771e1d14f616e23L1434-R1434) [[7]](diffhunk://#diff-1d410da5e0d716a6ce23d4b53049d7edf4c5840dfd3868f25771e1d14f616e23L1619-R1619)