### PR TITLE
Binance USDM API Documentation Update

### DIFF
--- a/docs/binance/usdm/private_rest_api.md
+++ b/docs/binance/usdm/private_rest_api.md
@@ -1894,7 +1894,6 @@ limit(X-MBX-ORDER-COUNT-1M); 1 on IP rate limit(x-mbx-used-weight-1m)
 >   - When the order is `GTX` and the new price will cause it to be executed
 >     immediately
 > - One order can only be modfied for less than 10000 times
-> - Modify order will set `selfTradePreventionMode` to `NONE`
 
 ### Response Example
 

--- a/docs/binance/usdm/private_websocket_api.md
+++ b/docs/binance/usdm/private_websocket_api.md
@@ -1609,8 +1609,8 @@ When new order created, order status changed will push such event. event type is
     "l": "0", // Order Last Filled Quantity
     "z": "0", // Order Filled Accumulated Quantity
     "L": "0", // Last Filled Price
-    "N": "USDT", // Commission Asset, will not push if no commission
-    "n": "0", // Commission, will not push if no commission
+    "N": "USDT", // Commission Asset
+    "n": "0", // Commission
     "T": 1568879465650, // Order Trade Time
     "t": 0, // Trade Id
     "b": "0", // Bids Notional


### PR DESCRIPTION
This pull request includes updates to the Binance API documentation for both the REST and WebSocket APIs. The changes primarily focus on clarifying behavior and simplifying descriptions.

### Updates to REST API Documentation:

* Removed the statement about modifying orders setting `selfTradePreventionMode` to `NONE` in the `docs/binance/usdm/private_rest_api.md` file. This change may indicate that the behavior is no longer applicable or has been updated.

### Updates to WebSocket API Documentation:

* Simplified the description of the `N` (Commission Asset) and `n` (Commission) fields by removing the condition about when these fields are pushed in the `docs/binance/usdm/private_websocket_api.md` file. This change makes the documentation more concise and easier to understand.