### PR TITLE
Binance Options API Documentation Update

### DIFF
--- a/docs/binance/coinm/private_rest_api.md
+++ b/docs/binance/coinm/private_rest_api.md
@@ -1202,7 +1202,6 @@ PUT `/dapi/v1/order`
 >   - When the order is `GTX` and the new price will cause it to be executed
 >     immediately
 > - One order can only be modfied for less than 10000 times
-> - Modify order will set `selfTradePreventionMode` to `NONE`
 
 ### Response Example
 

--- a/docs/binance/usdm/private_rest_api.md
+++ b/docs/binance/usdm/private_rest_api.md
@@ -1894,7 +1894,6 @@ limit(X-MBX-ORDER-COUNT-1M); 1 on IP rate limit(x-mbx-used-weight-1m)
 >   - When the order is `GTX` and the new price will cause it to be executed
 >     immediately
 > - One order can only be modfied for less than 10000 times
-> - Modify order will set `selfTradePreventionMode` to `NONE`
 
 ### Response Example
 

--- a/docs/binance/usdm/private_websocket_api.md
+++ b/docs/binance/usdm/private_websocket_api.md
@@ -1609,8 +1609,8 @@ When new order created, order status changed will push such event. event type is
     "l": "0", // Order Last Filled Quantity
     "z": "0", // Order Filled Accumulated Quantity
     "L": "0", // Last Filled Price
-    "N": "USDT", // Commission Asset, will not push if no commission
-    "n": "0", // Commission, will not push if no commission
+    "N": "USDT", // Commission Asset
+    "n": "0", // Commission
     "T": 1568879465650, // Order Trade Time
     "t": 0, // Trade Id
     "b": "0", // Bids Notional


### PR DESCRIPTION
This pull request includes documentation updates for Binance's private REST and WebSocket APIs. The changes primarily involve the removal of outdated or redundant information and the clarification of response details.

### Updates to REST API Documentation:

* [`docs/binance/coinm/private_rest_api.md`](diffhunk://#diff-4d7f03d89b5d1953cf1bbc79c3157c08a2ef7b2cfe93d0fb884804110bc02555L1205): Removed the statement indicating that modifying an order sets `selfTradePreventionMode` to `NONE`, as this behavior is no longer applicable.
* [`docs/binance/usdm/private_rest_api.md`](diffhunk://#diff-6a429050c9ed79c428442ad791bf05526d1f71ba2b2ea114d7ebe877dbadc5b7L1897): Similarly, removed the outdated note about `selfTradePreventionMode` being set to `NONE` when modifying an order.

### Updates to WebSocket API Documentation:

* [`docs/binance/usdm/private_websocket_api.md`](diffhunk://#diff-ef8f0bdaaebd20df79066c4f32c3a4975a195a394e646f2a261d214b553f7b17L1612-R1613): Simplified the description for commission-related fields (`N` and `n`) in the order status event by removing the condition about pushing only when a commission exists.