### PR TITLE
Binance Spot API Documentation Update

### DIFF
--- a/docs/binance/spot/change_log.md
+++ b/docs/binance/spot/change_log.md
@@ -2,7 +2,39 @@
 
 ## CHANGELOG for Binance's API
 
-**Last Updated: 2025-04-29**
+**Last Updated: 2025-05-22**
+
+#### 2025-05-22
+
+**Notice: The following changes will happen at 2025-06-06 7:00 UTC.**
+
+- The previous behavior of `recvWindow` on FIX, REST, and WebSocket APIs will be
+  augmented by an additional check.
+  - To review, the existing behavior is:
+    - If `timestamp` is greater than `serverTime` + 1 second at receipt of the
+      request, the request is rejected. Rejection by this check increments
+      message limits (FIX API) and IP limits (REST and WebSocket APIs), but not
+      Unfilled Order Count (order placement endpoints of all APIs).
+    - If the difference between `timestamp` and `serverTime` at receipt of the
+      request is greater than `recvWindow`, the request is rejected. Rejection
+      by this check increments message limits (FIX API) and IP limits (REST and
+      WebSocket APIs) but not Unfilled Order Count (order placement endpoints of
+      all APIs).
+  - The additional check is:
+    - Just before a request is forwarded to the Matching Engine, if the
+      difference between `timestamp` and the current `serverTime` is greater
+      than `recvWindow`, the request is rejected. Rejection by this check
+      increments message limits (FIX API), IP limits (REST and WebSocket APIs),
+      and Unfilled Order Count (order placement endpoints of all APIs).
+  - The documentation for Timing security has been updated to reflect the
+    additional check.
+    - [REST API](/docs/rest-api.md#timing-security)
+    - [WebSocket API](/docs/web-socket-api.md#timing-security)
+    - [FIX API](/docs/binance-spot-api-docs/fix-api#timing-security)
+- Fixed a bug in FIX Market Data message InstrumentList `<y>`. Previously, the
+  value of `NoRelatedSym(146)` could have been incorrect.
+
+---
 
 #### 2025-04-29
 

--- a/docs/binance/spot/fix_api.md
+++ b/docs/binance/spot/fix_api.md
@@ -133,6 +133,34 @@ change this behavior.
 - `ONLY_ACKS(2)`: Receive only ACK messages whether operation succeeded or
   failed. Disables ExecutionReport push.
 
+#### Timing Security
+
+- All requests require a `SendingTime(52)` field which should be the current
+  timestamp.
+- An additional optional field, `RecvWindow(25000)`, specifies for how long the
+  request stays valid in milliseconds.
+- If `RecvWindow(25000)` is not specified, it defaults to 5000 milliseconds only
+  for the Logon`<A>` request. For other requests if unset, the RecvWindow check
+  is not executed.
+  - Maximum `RecvWindow(25000)` is 60000 milliseconds.
+- Request processing logic is as follows:
+
+```javascript
+serverTime = getCurrentTime()
+if (SendingTime < (serverTime + 1 second) && (serverTime - SendingTime) <= RecvWindow) {
+  // begin processing request
+  serverTime = getCurrentTime()
+  if (serverTime - SendingTime) <= RecvWindow {
+    // forward request to Matching Engine
+  } else {
+    // reject request
+  }
+  // finish processing request
+} else {
+  // reject request
+}
+```
+
 #### How to sign Logon`<A>` request
 
 The [Logon`<A>`](/docs/binance-spot-api-docs/fix-api#logon-main) message

--- a/docs/binance/spot/private_rest_api.md
+++ b/docs/binance/spot/private_rest_api.md
@@ -911,20 +911,30 @@ the value it's looking for it will check the next one.
 
 #### Timing security
 
-- A `SIGNED` endpoint also requires a parameter, `timestamp`, to be sent which
-  should be the millisecond timestamp of when the request was created and sent.
-- An additional parameter, `recvWindow`, may be sent to specify the number of
-  milliseconds after `timestamp` the request is valid for. If `recvWindow` is
-  not sent, **it defaults to 5000**.
-- The logic is as follows:
+- `SIGNED` requests also require a `timestamp` parameter which should be the
+  current timestamp either in milliseconds or microseconds. (See
+  [General API Information](/docs/binance-spot-api-docs/rest-api/endpoint-security-type#general-api-information))
+- An additional optional parameter, `recvWindow`, specifies for how long the
+  request stays valid and may only be specified in milliseconds.
+  - If `recvWindow` is not sent, **it defaults to 5000 milliseconds**.
+  - Maximum `recvWindow` is 60000 milliseconds.
+- Request processing logic is as follows:
 
-  ```javascript
-  if (timestamp < serverTime + 1000 && serverTime - timestamp <= recvWindow) {
-    // process request
+```javascript
+serverTime = getCurrentTime()
+if (timestamp < (serverTime + 1 second) && (serverTime - timestamp) <= recvWindow) {
+  // begin processing request
+  serverTime = getCurrentTime()
+  if (serverTime - timestamp) <= recvWindow {
+    // forward request to Matching Engine
   } else {
     // reject request
   }
-  ```
+  // finish processing request
+} else {
+  // reject request
+}
+```
 
 **Serious trading is about timing.** Networks can be unstable and unreliable,
 which can lead to requests taking varying amounts of time to reach the servers.

--- a/docs/binance/spot/private_websocket_api.md
+++ b/docs/binance/spot/private_websocket_api.md
@@ -1941,22 +1941,29 @@ Event fields:
 #### Timing security
 
 - `SIGNED` requests also require a `timestamp` parameter which should be the
-  current millisecond timestamp.
+  current timestamp either in milliseconds or microseconds. (See
+  [General API Information](/docs/binance-spot-api-docs/websocket-api/request-security#general-api-information))
 - An additional optional parameter, `recvWindow`, specifies for how long the
-  request stays valid.
-
+  request stays valid and may only be specified in milliseconds.
   - If `recvWindow` is not sent, **it defaults to 5000 milliseconds**.
   - Maximum `recvWindow` is 60000 milliseconds.
-
 - Request processing logic is as follows:
 
-  ```javascript
-  if (timestamp < serverTime + 1000 && serverTime - timestamp <= recvWindow) {
-    // process request
+```javascript
+serverTime = getCurrentTime()
+if (timestamp < (serverTime + 1 second) && (serverTime - timestamp) <= recvWindow) {
+  // begin processing request
+  serverTime = getCurrentTime()
+  if (serverTime - timestamp) <= recvWindow {
+    // forward request to Matching Engine
   } else {
     // reject request
   }
-  ```
+  // finish processing request
+} else {
+  // reject request
+}
+```
 
 **Serious trading is about timing.** Networks can be unstable and unreliable,
 which can lead to requests taking varying amounts of time to reach the servers.

--- a/docs/binance/spot/public_rest_api.md
+++ b/docs/binance/spot/public_rest_api.md
@@ -911,20 +911,30 @@ the value it's looking for it will check the next one.
 
 #### Timing security
 
-- A `SIGNED` endpoint also requires a parameter, `timestamp`, to be sent which
-  should be the millisecond timestamp of when the request was created and sent.
-- An additional parameter, `recvWindow`, may be sent to specify the number of
-  milliseconds after `timestamp` the request is valid for. If `recvWindow` is
-  not sent, **it defaults to 5000**.
-- The logic is as follows:
+- `SIGNED` requests also require a `timestamp` parameter which should be the
+  current timestamp either in milliseconds or microseconds. (See
+  [General API Information](/docs/binance-spot-api-docs/rest-api/endpoint-security-type#general-api-information))
+- An additional optional parameter, `recvWindow`, specifies for how long the
+  request stays valid and may only be specified in milliseconds.
+  - If `recvWindow` is not sent, **it defaults to 5000 milliseconds**.
+  - Maximum `recvWindow` is 60000 milliseconds.
+- Request processing logic is as follows:
 
-  ```javascript
-  if (timestamp < serverTime + 1000 && serverTime - timestamp <= recvWindow) {
-    // process request
+```javascript
+serverTime = getCurrentTime()
+if (timestamp < (serverTime + 1 second) && (serverTime - timestamp) <= recvWindow) {
+  // begin processing request
+  serverTime = getCurrentTime()
+  if (serverTime - timestamp) <= recvWindow {
+    // forward request to Matching Engine
   } else {
     // reject request
   }
-  ```
+  // finish processing request
+} else {
+  // reject request
+}
+```
 
 **Serious trading is about timing.** Networks can be unstable and unreliable,
 which can lead to requests taking varying amounts of time to reach the servers.

--- a/docs/binance/spot/public_websocket_api.md
+++ b/docs/binance/spot/public_websocket_api.md
@@ -1951,22 +1951,29 @@ Successful response indicating that you have placed 12 orders in 10 seconds, and
 #### Timing security
 
 - `SIGNED` requests also require a `timestamp` parameter which should be the
-  current millisecond timestamp.
+  current timestamp either in milliseconds or microseconds. (See
+  [General API Information](/docs/binance-spot-api-docs/websocket-api/request-security#general-api-information))
 - An additional optional parameter, `recvWindow`, specifies for how long the
-  request stays valid.
-
+  request stays valid and may only be specified in milliseconds.
   - If `recvWindow` is not sent, **it defaults to 5000 milliseconds**.
   - Maximum `recvWindow` is 60000 milliseconds.
-
 - Request processing logic is as follows:
 
-  ```javascript
-  if (timestamp < serverTime + 1000 && serverTime - timestamp <= recvWindow) {
-    // process request
+```javascript
+serverTime = getCurrentTime()
+if (timestamp < (serverTime + 1 second) && (serverTime - timestamp) <= recvWindow) {
+  // begin processing request
+  serverTime = getCurrentTime()
+  if (serverTime - timestamp) <= recvWindow {
+    // forward request to Matching Engine
   } else {
     // reject request
   }
-  ```
+  // finish processing request
+} else {
+  // reject request
+}
+```
 
 **Serious trading is about timing.** Networks can be unstable and unreliable,
 which can lead to requests taking varying amounts of time to reach the servers.


### PR DESCRIPTION
This pull request updates the documentation for Binance's APIs to reflect changes in timing security and processing logic for `recvWindow` across FIX, REST, and WebSocket APIs. It also fixes a bug in the FIX Market Data message. Below are the key changes grouped by theme:

### Timing Security Updates:
* Updated the timing security logic for all APIs to include an additional check before forwarding requests to the Matching Engine. This ensures that requests exceeding the `recvWindow` are rejected at this stage. [[1]](diffhunk://#diff-af5680cbde1fbca404443e5347bb0e99dc8838f31db22eef370f478593a6675eL5-R37) [[2]](diffhunk://#diff-24bab40ffdb2b88a5b62ffb0dc80c8592b0e999f94b4c77621f3d3fdda1768bfR136-R163) [[3]](diffhunk://#diff-0fd860f4c27103a1db4f0a313d2e261bcc9a615ec0c015a59f6d85b040af8a9aL914-R933) [[4]](diffhunk://#diff-a77f386cedbd3d817db1f18b205b2852ecf523d58d8ccdb251f5e32e4bec0733L1944-R1962) [[5]](diffhunk://#diff-6c1da7cf7fcdf643708e730152bb54f2e4f17641624bf4fc7b8cdc4eb0a24551L914-R933) [[6]](diffhunk://#diff-8fd629f7ad6fb890df0d0ec59a8d07dce509f1d7b5f8862c52b4a9b6d63be5e1L1954-R1972)
* Clarified that `timestamp` can now be specified in milliseconds or microseconds, and updated the maximum `recvWindow` to 60000 milliseconds. Default behavior and examples were updated across FIX, REST, and WebSocket API documentation. [[1]](diffhunk://#diff-24bab40ffdb2b88a5b62ffb0dc80c8592b0e999f94b4c77621f3d3fdda1768bfR136-R163) [[2]](diffhunk://#diff-0fd860f4c27103a1db4f0a313d2e261bcc9a615ec0c015a59f6d85b040af8a9aL914-R933) [[3]](diffhunk://#diff-a77f386cedbd3d817db1f18b205b2852ecf523d58d8ccdb251f5e32e4bec0733L1944-R1962) [[4]](diffhunk://#diff-6c1da7cf7fcdf643708e730152bb54f2e4f17641624bf4fc7b8cdc4eb0a24551L914-R933) [[5]](diffhunk://#diff-8fd629f7ad6fb890df0d0ec59a8d07dce509f1d7b5f8862c52b4a9b6d63be5e1L1954-R1972)

### FIX API Bug Fix:
* Resolved an issue in the FIX Market Data message `InstrumentList` where the value of `NoRelatedSym(146)` could have been incorrect.