### PR TITLE
Binance Spot API Documentation Update

### DIFF
--- a/docs/binance/spot/private_rest_api.md
+++ b/docs/binance/spot/private_rest_api.md
@@ -1367,7 +1367,7 @@ filter.
 | ------------------------- | --------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | \-symbol                  | \-STRING  | \-YES     |                                                                                                                                                                                                           |
 | \-side                    | \-ENUM    | \-YES     | \-Please see [Enums](/docs/binance-spot-api-docs/enums#side) for supported values.                                                                                                                        |
-| \-type                    | \-ENUM    | \-YES     | \-Please see [Enums](/docs/binance-spot-api-docs/enums#ordertypes) for supported values                                                                                                                   |
+| \-type                    | \-ENUM    | \-YES     | \-Please see [Enums](/docs/binance-spot-api-docs/enums#ordertypes) for supported values.                                                                                                                  |
 | \-timeInForce             | \-ENUM    | \-NO      | \-Please see [Enums](/docs/binance-spot-api-docs/enums#timeinforce) for supported values.                                                                                                                 |
 | \-quantity                | \-DECIMAL | \-NO      |                                                                                                                                                                                                           |
 | \-quoteOrderQty           | \-DECIMAL | \-NO      |                                                                                                                                                                                                           |
@@ -1376,7 +1376,7 @@ filter.
 | \-strategyId              | \-LONG    | \-NO      |                                                                                                                                                                                                           |
 | \-strategyType            | \-INT     | \-NO      | \-The value cannot be less than `1000000`.                                                                                                                                                                |
 | \-stopPrice               | \-DECIMAL | \-NO      | \-Used with `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.                                                                                                                |
-| \-trailingDelta           | \-LONG    | \-NO      | \-Used with `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, and `TAKE_PROFIT_LIMIT` orders.                                                                                                                |
+| \-trailingDelta           | \-LONG    | \-NO      | \-See [Trailing Stop order FAQ](/docs/binance-spot-api-docs/faqs/trailing-stop-faq).                                                                                                                      |
 | \-icebergQty              | \-DECIMAL | \-NO      | \-Used with `LIMIT`, `STOP_LOSS_LIMIT`, and `TAKE_PROFIT_LIMIT` to create an iceberg order.                                                                                                               |
 | \-newOrderRespType        | \-ENUM    | \-NO      | \-Set the response JSON. `ACK`, `RESULT`, or `FULL`; `MARKET` and `LIMIT` order types default to `FULL`, all other orders default to `ACK`.                                                               |
 | \-selfTradePreventionMode | \-ENUM    | \-NO      | \-The allowed enums is dependent on what is configured on the symbol. The possible supported values are: [STP Modes](/docs/binance-spot-api-docs/enums#stpmodes).                                         |
@@ -1588,69 +1588,6 @@ With `computeCommissionRates`
 }
 ```
 
-#### Query order (USER_DATA)
-
-```null
-GET /api/v3/order
-```
-
-Check an order's status.
-
-**Weight:** 4
-
-**Parameters:**
-
-| Name                | Type     | Mandatory | Description                                |
-| ------------------- | -------- | --------- | ------------------------------------------ |
-| \-symbol            | \-STRING | \-YES     |                                            |
-| \-orderId           | \-LONG   | \-NO      |                                            |
-| \-origClientOrderId | \-STRING | \-NO      |                                            |
-| \-recvWindow        | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
-| \-timestamp         | \-LONG   | \-YES     |                                            |
-
-**Notes:**
-
-- Either `orderId` or `origClientOrderId` must be sent.
-- If both `orderId` and `origClientOrderId` are provided, the `orderId` is
-  searched first, then the `origClientOrderId` from that result is checked
-  against that order. If both conditions are not met the request will be
-  rejected.
-- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data
-  is not available at this time.
-
-**Data Source:** Memory => Database
-
-**Response:**
-
-```json
-{
-  "symbol": "LTCBTC",
-  "orderId": 1,
-  "orderListId": -1, // This field will always have a value of -1 if not an order list.
-  "clientOrderId": "myOrder1",
-  "price": "0.1",
-  "origQty": "1.0",
-  "executedQty": "0.0",
-  "cummulativeQuoteQty": "0.0",
-  "status": "NEW",
-  "timeInForce": "GTC",
-  "type": "LIMIT",
-  "side": "BUY",
-  "stopPrice": "0.0",
-  "icebergQty": "0.0",
-  "time": 1499827319559,
-  "updateTime": 1499827319559,
-  "isWorking": true,
-  "workingTime": 1499827319559,
-  "origQuoteOrderQty": "0.000000",
-  "selfTradePreventionMode": "NONE"
-}
-```
-
-**Note:** The payload above does not show all fields that can appear. Please
-refer to
-[Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
-
 #### Cancel order (TRADE)
 
 ```null
@@ -1696,6 +1633,7 @@ Notes:
   "price": "2.00000000",
   "origQty": "1.00000000",
   "executedQty": "0.00000000",
+  "origQuoteOrderQty": "0.000000",
   "cummulativeQuoteQty": "0.00000000",
   "status": "CANCELED",
   "timeInForce": "GTC",
@@ -1711,7 +1649,7 @@ Notes:
   response. Please refer to
   [Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
 - The performance for canceling an order (single cancel or as part of a
-  cancel-replace) is always better when only orderId is sent. Sending
+  cancel-replace) is always better when only `orderId` is sent. Sending
   `origClientOrderId` or both `orderId` + `origClientOrderId` will be slower.
 
 **Regarding `cancelRestrictions`**
@@ -1771,6 +1709,7 @@ order list.
     "price": "0.089853",
     "origQty": "0.178622",
     "executedQty": "0.000000",
+    "origQuoteOrderQty": "0.000000",
     "cummulativeQuoteQty": "0.000000",
     "status": "CANCELED",
     "timeInForce": "GTC",
@@ -1788,6 +1727,7 @@ order list.
     "price": "0.090430",
     "origQty": "0.178622",
     "executedQty": "0.000000",
+    "origQuoteOrderQty": "0.000000",
     "cummulativeQuoteQty": "0.000000",
     "status": "CANCELED",
     "timeInForce": "GTC",
@@ -1826,6 +1766,7 @@ order list.
         "price": "0.668611",
         "origQty": "0.690354",
         "executedQty": "0.000000",
+        "origQuoteOrderQty": "0.000000",
         "cummulativeQuoteQty": "0.000000",
         "status": "CANCELED",
         "timeInForce": "GTC",
@@ -1845,6 +1786,7 @@ order list.
         "price": "0.008791",
         "origQty": "0.690354",
         "executedQty": "0.000000",
+        "origQuoteOrderQty": "0.000000",
         "cummulativeQuoteQty": "0.000000",
         "status": "CANCELED",
         "timeInForce": "GTC",
@@ -1944,7 +1886,7 @@ succeeded, partially succeeded, or failed.
 | \-❌ `FAILURE`      | \-✅ `SUCCESS`               | \-N/A                |
 | \-✅ `SUCCESS`      | \-❌ `FAILURE`               | \-`409`              |
 
-**Response SUCCESS unfilled order count is not exceeded:**
+**Response SUCCESS and account has not exceeded the unfilled order count:**
 
 ```javascript
 // Both the cancel order placement and new order placement succeeded.
@@ -1978,8 +1920,8 @@ succeeded, partially succeeded, or failed.
     "price": "0.02000000",
     "origQty": "0.040000",
     "executedQty": "0.00000000",
-    "cummulativeQuoteQty": "0.00000000",
     "origQuoteOrderQty": "0.000000",
+    "cummulativeQuoteQty": "0.00000000",
     "status": "NEW",
     "timeInForce": "GTC",
     "type": "LIMIT",
@@ -1992,7 +1934,7 @@ succeeded, partially succeeded, or failed.
 ```
 
 **Response when Cancel Order Fails with STOP_ON FAILURE and account has not
-exceeded unfilled order count:**
+exceeded their unfilled order count:**
 
 ```json
 {
@@ -2011,7 +1953,7 @@ exceeded unfilled order count:**
 ```
 
 **Response when Cancel Order Succeeds but New Order Placement Fails and account
-has not exceeded the unfilled order count:**
+has not exceeded their unfilled order count:**
 
 ```json
 {
@@ -2046,7 +1988,7 @@ has not exceeded the unfilled order count:**
 ```
 
 **Response when Cancel Order fails with ALLOW_FAILURE and account has not
-exceeded the unfilled order count:**
+exceeded their unfilled order count:**
 
 ```json
 {
@@ -2071,7 +2013,7 @@ exceeded the unfilled order count:**
 ```
 
 **Response when both Cancel Order and New Order Placement fail using
-`cancelReplaceMode=ALLOW_FAILURE` and account has not exceeded the unfilled
+`cancelReplaceMode=ALLOW_FAILURE` and account has not exceeded their unfilled
 order count:**
 
 ```json
@@ -2258,128 +2200,6 @@ Response for an order that is part of an Order list:
 refer to
 [Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
 
-#### Current open orders (USER_DATA)
-
-```null
-GET /api/v3/openOrders
-```
-
-Get all open orders on a symbol. **Careful** when accessing this with no symbol.
-
-**Weight:** 6 for a single symbol; **80** when the symbol parameter is omitted
-
-**Parameters:**
-
-| Name         | Type     | Mandatory | Description                                |
-| ------------ | -------- | --------- | ------------------------------------------ |
-| \-symbol     | \-STRING | \-NO      |                                            |
-| \-recvWindow | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
-| \-timestamp  | \-LONG   | \-YES     |                                            |
-
-- If the symbol is not sent, orders for all symbols will be returned in an
-  array.
-
-**Data Source:** Memory => Database
-
-**Response:**
-
-```json
-[
-  {
-    "symbol": "LTCBTC",
-    "orderId": 1,
-    "orderListId": -1, // Unless it's part of an order list, value will be -1
-    "clientOrderId": "myOrder1",
-    "price": "0.1",
-    "origQty": "1.0",
-    "executedQty": "0.0",
-    "cummulativeQuoteQty": "0.0",
-    "status": "NEW",
-    "timeInForce": "GTC",
-    "type": "LIMIT",
-    "side": "BUY",
-    "stopPrice": "0.0",
-    "icebergQty": "0.0",
-    "time": 1499827319559,
-    "updateTime": 1499827319559,
-    "isWorking": true,
-    "origQuoteOrderQty": "0.000000",
-    "workingTime": 1499827319559,
-    "selfTradePreventionMode": "NONE"
-  }
-]
-```
-
-**Note:** The payload above does not show all fields that can appear. Please
-refer to
-[Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
-
-#### All orders (USER_DATA)
-
-```null
-GET /api/v3/allOrders
-```
-
-Get all account orders; active, canceled, or filled.
-
-**Weight:** 20
-
-**Data Source:** Database
-
-**Parameters:**
-
-| Name         | Type     | Mandatory | Description                                |
-| ------------ | -------- | --------- | ------------------------------------------ |
-| \-symbol     | \-STRING | \-YES     |                                            |
-| \-orderId    | \-LONG   | \-NO      |                                            |
-| \-startTime  | \-LONG   | \-NO      |                                            |
-| \-endTime    | \-LONG   | \-NO      |                                            |
-| \-limit      | \-INT    | \-NO      | \-Default: 500; Maximum: 1000.             |
-| \-recvWindow | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
-| \-timestamp  | \-LONG   | \-YES     |                                            |
-
-**Notes:**
-
-- If `orderId` is set, it will get orders >= that `orderId`. Otherwise most
-  recent orders are returned.
-- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data
-  is not available at this time.
-- If `startTime` and/or `endTime` provided, `orderId` is not required.
-- The time between `startTime` and `endTime` can't be longer than 24 hours.
-
-**Response:**
-
-```json
-[
-  {
-    "symbol": "LTCBTC",
-    "orderId": 1,
-    "orderListId": -1, //Unless it's part of an order list, value will be -1
-    "clientOrderId": "myOrder1",
-    "price": "0.1",
-    "origQty": "1.0",
-    "executedQty": "0.0",
-    "cummulativeQuoteQty": "0.0",
-    "status": "NEW",
-    "timeInForce": "GTC",
-    "type": "LIMIT",
-    "side": "BUY",
-    "stopPrice": "0.0",
-    "icebergQty": "0.0",
-    "time": 1499827319559,
-    "updateTime": 1499827319559,
-    "isWorking": true,
-    "origQuoteOrderQty": "0.000000",
-    "workingTime": 1499827319559,
-    "selfTradePreventionMode": "NONE"
-  }
-]
-```
-
-**Note:** The payload above does not show all fields that can appear. Please
-refer to
-[Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
-
 #### Order lists
 
 ##### New OCO - Deprecated (TRADE)
@@ -2537,7 +2357,7 @@ immediately cancels the other.
 | \-aboveClientOrderId      | \-STRING  | \-No      | \-Arbitrary unique ID among open orders for the above order. Automatically generated if not sent                                                                                                                                                                                                          |
 | \-aboveIcebergQty         | \-LONG    | \-No      | \-Note that this can only be used if `aboveTimeInForce` is `GTC`.                                                                                                                                                                                                                                         |
 | \-abovePrice              | \-DECIMAL | \-No      | \-Can be used if `aboveType` is `STOP_LOSS_LIMIT` , `LIMIT_MAKER`, or `TAKE_PROFIT_LIMIT` to specify the limit price.                                                                                                                                                                                     |
-| \-aboveStopPrice          | \-DECIMAL | \-No      | \-Can be used if `aboveType` is `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, `TAKE_PROFIT_LIMIT` Either `aboveStopPrice` or `aboveTrailingDelta` or both, must be specified.                                                                                                                            |
+| \-aboveStopPrice          | \-DECIMAL | \-No      | \-Can be used if `aboveType` is `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, `TAKE_PROFIT_LIMIT`. Either `aboveStopPrice` or `aboveTrailingDelta` or both, must be specified.                                                                                                                           |
 | \-aboveTrailingDelta      | \-LONG    | \-No      | \-See [Trailing Stop order FAQ](/docs/binance-spot-api-docs/faqs/trailing-stop-faq).                                                                                                                                                                                                                      |
 | \-aboveTimeInForce        | \-DECIMAL | \-No      | \-Required if `aboveType` is `STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT`                                                                                                                                                                                                                                     |
 | \-aboveStrategyId         | \-LONG    | \-No      | \-Arbitrary numeric value identifying the above order within an order strategy.                                                                                                                                                                                                                           |
@@ -2545,7 +2365,7 @@ immediately cancels the other.
 | \-belowType               | \-ENUM    | \-Yes     | \-Supported values: `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`,`TAKE_PROFIT_LIMIT`                                                                                                                                                                                                                     |
 | \-belowClientOrderId      | \-STRING  | \-No      | \-Arbitrary unique ID among open orders for the below order. Automatically generated if not sent                                                                                                                                                                                                          |
 | \-belowIcebergQty         | \-LONG    | \-No      | \-Note that this can only be used if `belowTimeInForce` is `GTC`.                                                                                                                                                                                                                                         |
-| \-belowPrice              | \-DECIMAL | \-No      | \-Can be used if `belowType` is `STOP_LOSS_LIMIT` , `LIMIT_MAKER`, or `TAKE_PROFIT_LIMIT` to specify the limit price.                                                                                                                                                                                     |
+| \-belowPrice              | \-DECIMAL | \-No      | \-Can be used if `belowType` is `STOP_LOSS_LIMIT`, `LIMIT_MAKER`, or `TAKE_PROFIT_LIMIT` to specify the limit price.                                                                                                                                                                                      |
 | \-belowStopPrice          | \-DECIMAL | \-No      | \-Can be used if `belowType` is `STOP_LOSS`, `STOP_LOSS_LIMIT, TAKE_PROFIT` or `TAKE_PROFIT_LIMIT` Either belowStopPrice or belowTrailingDelta or both, must be specified.                                                                                                                                |
 | \-belowTrailingDelta      | \-LONG    | \-No      | \-See [Trailing Stop order FAQ](/docs/binance-spot-api-docs/faqs/trailing-stop-faq).                                                                                                                                                                                                                      |
 | \-belowTimeInForce        | \-ENUM    | \-No      | \-Required if `belowType` is `STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT`.                                                                                                                                                                                                                                    |
@@ -2635,7 +2455,7 @@ for more examples.
 POST /api/v3/orderList/oto
 ```
 
-Places an OTO.
+Place an OTO.
 
 - An OTO (One-Triggers-the-Other) is an order list comprised of 2 orders.
 - The first order is called the **working order** and must be `LIMIT` or
@@ -2713,7 +2533,7 @@ Matching Engine
   "listOrderStatus": "EXECUTING",
   "listClientOrderId": "yl2ERtcar1o25zcWtqVBTC",
   "transactionTime": 1712289389158,
-  "symbol": "ABCDEF",
+  "symbol": "LTCBTC",
   "orders": [
     {
       "symbol": "LTCBTC",
@@ -2868,7 +2688,7 @@ Matching Engine
   "listOrderStatus": "EXECUTING",
   "listClientOrderId": "RumwQpBaDctlUu5jyG5rs0",
   "transactionTime": 1712291372842,
-  "symbol": "ABCDEF",
+  "symbol": "LTCBTC",
   "orders": [
     {
       "symbol": "LTCBTC",
@@ -3045,173 +2865,6 @@ Cancel an entire Order list
     }
   ]
 }
-```
-
-##### Query Order list (USER_DATA)
-
-```null
-GET /api/v3/orderList
-```
-
-Retrieves a specific order list based on provided optional parameters.
-
-**Weight:** 4
-
-**Parameters:**
-
-| Name                | Type     | Mandatory | Description                                                                                       |
-| ------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
-| \-orderListId       | \-LONG   | \-NO\*    | \-Query order list by `orderListId`. `orderListId` or `origClientOrderId` must be provided.       |
-| \-origClientOrderId | \-STRING | \-NO\*    | \-Query order list by `listClientOrderId`. `orderListId` or `origClientOrderId` must be provided. |
-| \-recvWindow        | \-LONG   | \-NO      | \-The value cannot be greater than `60000`                                                        |
-| \-timestamp         | \-LONG   | \-YES     |                                                                                                   |
-
-**Data Source:** Database
-
-**Response:**
-
-```json
-{
-  "orderListId": 27,
-  "contingencyType": "OCO",
-  "listStatusType": "EXEC_STARTED",
-  "listOrderStatus": "EXECUTING",
-  "listClientOrderId": "h2USkA5YQpaXHPIrkd96xE",
-  "transactionTime": 1565245656253,
-  "symbol": "LTCBTC",
-  "orders": [
-    {
-      "symbol": "LTCBTC",
-      "orderId": 4,
-      "clientOrderId": "qD1gy3kc3Gx0rihm9Y3xwS"
-    },
-    {
-      "symbol": "LTCBTC",
-      "orderId": 5,
-      "clientOrderId": "ARzZ9I00CPM8i3NhmU9Ega"
-    }
-  ]
-}
-```
-
-##### Query all Order lists (USER_DATA)
-
-```null
-GET /api/v3/allOrderList
-```
-
-Retrieves all order lists based on provided optional parameters.
-
-Note that the time between `startTime` and `endTime` can't be longer than 24
-hours.
-
-**Weight:** 20
-
-**Parameters:**
-
-| Name         | Type   | Mandatory | Description                                                     |
-| ------------ | ------ | --------- | --------------------------------------------------------------- |
-| \-fromId     | \-LONG | \-NO      | \-If supplied, neither `startTime` or `endTime` can be provided |
-| \-startTime  | \-LONG | \-NO      |                                                                 |
-| \-endTime    | \-LONG | \-NO      |                                                                 |
-| \-limit      | \-INT  | \-NO      | \-Default: 500; Maximum: 1000                                   |
-| \-recvWindow | \-LONG | \-NO      | \-The value cannot be greater than `60000`                      |
-| \-timestamp  | \-LONG | \-YES     |                                                                 |
-
-**Data Source:** Database
-
-**Response:**
-
-```json
-[
-  {
-    "orderListId": 29,
-    "contingencyType": "OCO",
-    "listStatusType": "EXEC_STARTED",
-    "listOrderStatus": "EXECUTING",
-    "listClientOrderId": "amEEAXryFzFwYF1FeRpUoZ",
-    "transactionTime": 1565245913483,
-    "symbol": "LTCBTC",
-    "orders": [
-      {
-        "symbol": "LTCBTC",
-        "orderId": 4,
-        "clientOrderId": "oD7aesZqjEGlZrbtRpy5zB"
-      },
-      {
-        "symbol": "LTCBTC",
-        "orderId": 5,
-        "clientOrderId": "Jr1h6xirOxgeJOUuYQS7V3"
-      }
-    ]
-  },
-  {
-    "orderListId": 28,
-    "contingencyType": "OCO",
-    "listStatusType": "EXEC_STARTED",
-    "listOrderStatus": "EXECUTING",
-    "listClientOrderId": "hG7hFNxJV6cZy3Ze4AUT4d",
-    "transactionTime": 1565245913407,
-    "symbol": "LTCBTC",
-    "orders": [
-      {
-        "symbol": "LTCBTC",
-        "orderId": 2,
-        "clientOrderId": "j6lFOfbmFMRjTYA7rRJ0LP"
-      },
-      {
-        "symbol": "LTCBTC",
-        "orderId": 3,
-        "clientOrderId": "z0KCjOdditiLS5ekAFtK81"
-      }
-    ]
-  }
-]
-```
-
-##### Query Open Order lists (USER_DATA)
-
-```null
-GET /api/v3/openOrderList
-```
-
-**Weight:** 6
-
-**Parameters:**
-
-| Name         | Type   | Mandatory | Description                                |
-| ------------ | ------ | --------- | ------------------------------------------ |
-| \-recvWindow | \-LONG | \-NO      | \-The value cannot be greater than `60000` |
-| \-timestamp  | \-LONG | \-YES     |                                            |
-
-**Data Source:** Database
-
-**Response:**
-
-```json
-[
-  {
-    "orderListId": 31,
-    "contingencyType": "OCO",
-    "listStatusType": "EXEC_STARTED",
-    "listOrderStatus": "EXECUTING",
-    "listClientOrderId": "wuB13fmulKj3YjdqWEcsnp",
-    "transactionTime": 1565246080644,
-    "symbol": "LTCBTC",
-    "orders": [
-      {
-        "symbol": "LTCBTC",
-        "orderId": 4,
-        "clientOrderId": "r3EH2N76dHfLoSZWIUw1bT"
-      },
-      {
-        "symbol": "LTCBTC",
-        "orderId": 5,
-        "clientOrderId": "Cv1SnyPD3qhqpbjpYEHbd2"
-      }
-    ]
-  }
-]
 ```
 
 #### SOR
@@ -3416,6 +3069,358 @@ Get current account information.
   "permissions": ["SPOT"],
   "uid": 354937868
 }
+```
+
+#### Query order (USER_DATA)
+
+```null
+GET /api/v3/order
+```
+
+Check an order's status.
+
+**Weight:** 4
+
+**Parameters:**
+
+| Name                | Type     | Mandatory | Description                                |
+| ------------------- | -------- | --------- | ------------------------------------------ |
+| \-symbol            | \-STRING | \-YES     |                                            |
+| \-orderId           | \-LONG   | \-NO      |                                            |
+| \-origClientOrderId | \-STRING | \-NO      |                                            |
+| \-recvWindow        | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
+| \-timestamp         | \-LONG   | \-YES     |                                            |
+
+**Notes:**
+
+- Either `orderId` or `origClientOrderId` must be sent.
+- If both `orderId` and `origClientOrderId` are provided, the `orderId` is
+  searched first, then the `origClientOrderId` from that result is checked
+  against that order. If both conditions are not met the request will be
+  rejected.
+- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data
+  is not available at this time.
+
+**Data Source:** Memory => Database
+
+**Response:**
+
+```json
+{
+  "symbol": "LTCBTC",
+  "orderId": 1,
+  "orderListId": -1, // This field will always have a value of -1 if not an order list.
+  "clientOrderId": "myOrder1",
+  "price": "0.1",
+  "origQty": "1.0",
+  "executedQty": "0.0",
+  "cummulativeQuoteQty": "0.0",
+  "status": "NEW",
+  "timeInForce": "GTC",
+  "type": "LIMIT",
+  "side": "BUY",
+  "stopPrice": "0.0",
+  "icebergQty": "0.0",
+  "time": 1499827319559,
+  "updateTime": 1499827319559,
+  "isWorking": true,
+  "workingTime": 1499827319559,
+  "origQuoteOrderQty": "0.000000",
+  "selfTradePreventionMode": "NONE"
+}
+```
+
+**Note:** The payload above does not show all fields that can appear. Please
+refer to
+[Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
+
+#### Current open orders (USER_DATA)
+
+```null
+GET /api/v3/openOrders
+```
+
+Get all open orders on a symbol. **Careful** when accessing this with no symbol.
+
+**Weight:** 6 for a single symbol; **80** when the symbol parameter is omitted
+
+**Parameters:**
+
+| Name         | Type     | Mandatory | Description                                |
+| ------------ | -------- | --------- | ------------------------------------------ |
+| \-symbol     | \-STRING | \-NO      |                                            |
+| \-recvWindow | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
+| \-timestamp  | \-LONG   | \-YES     |                                            |
+
+- If the symbol is not sent, orders for all symbols will be returned in an
+  array.
+
+**Data Source:** Memory => Database
+
+**Response:**
+
+```json
+[
+  {
+    "symbol": "LTCBTC",
+    "orderId": 1,
+    "orderListId": -1, // Unless it's part of an order list, value will be -1
+    "clientOrderId": "myOrder1",
+    "price": "0.1",
+    "origQty": "1.0",
+    "executedQty": "0.0",
+    "cummulativeQuoteQty": "0.0",
+    "status": "NEW",
+    "timeInForce": "GTC",
+    "type": "LIMIT",
+    "side": "BUY",
+    "stopPrice": "0.0",
+    "icebergQty": "0.0",
+    "time": 1499827319559,
+    "updateTime": 1499827319559,
+    "isWorking": true,
+    "origQuoteOrderQty": "0.000000",
+    "workingTime": 1499827319559,
+    "selfTradePreventionMode": "NONE"
+  }
+]
+```
+
+**Note:** The payload above does not show all fields that can appear. Please
+refer to
+[Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
+
+#### All orders (USER_DATA)
+
+```null
+GET /api/v3/allOrders
+```
+
+Get all account orders; active, canceled, or filled.
+
+**Weight:** 20
+
+**Data Source:** Database
+
+**Parameters:**
+
+| Name         | Type     | Mandatory | Description                                |
+| ------------ | -------- | --------- | ------------------------------------------ |
+| \-symbol     | \-STRING | \-YES     |                                            |
+| \-orderId    | \-LONG   | \-NO      |                                            |
+| \-startTime  | \-LONG   | \-NO      |                                            |
+| \-endTime    | \-LONG   | \-NO      |                                            |
+| \-limit      | \-INT    | \-NO      | \-Default: 500; Maximum: 1000.             |
+| \-recvWindow | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
+| \-timestamp  | \-LONG   | \-YES     |                                            |
+
+**Notes:**
+
+- If `orderId` is set, it will get orders >= that `orderId`. Otherwise most
+  recent orders are returned.
+- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data
+  is not available at this time.
+- If `startTime` and/or `endTime` provided, `orderId` is not required.
+- The time between `startTime` and `endTime` can't be longer than 24 hours.
+
+**Response:**
+
+```json
+[
+  {
+    "symbol": "LTCBTC",
+    "orderId": 1,
+    "orderListId": -1, //Unless it's part of an order list, value will be -1
+    "clientOrderId": "myOrder1",
+    "price": "0.1",
+    "origQty": "1.0",
+    "executedQty": "0.0",
+    "cummulativeQuoteQty": "0.0",
+    "status": "NEW",
+    "timeInForce": "GTC",
+    "type": "LIMIT",
+    "side": "BUY",
+    "stopPrice": "0.0",
+    "icebergQty": "0.0",
+    "time": 1499827319559,
+    "updateTime": 1499827319559,
+    "isWorking": true,
+    "origQuoteOrderQty": "0.000000",
+    "workingTime": 1499827319559,
+    "selfTradePreventionMode": "NONE"
+  }
+]
+```
+
+**Note:** The payload above does not show all fields that can appear. Please
+refer to
+[Conditional fields in Order Responses](/docs/binance-spot-api-docs/rest-api/trading-endpoints#conditional-fields-in-order-responses).
+
+#### Query Order list (USER_DATA)
+
+```null
+GET /api/v3/orderList
+```
+
+Retrieves a specific order list based on provided optional parameters.
+
+**Weight:** 4
+
+**Parameters:**
+
+| Name                | Type     | Mandatory | Description                                                                                       |
+| ------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------- |
+| \-orderListId       | \-LONG   | \-NO\*    | \-Query order list by `orderListId`. `orderListId` or `origClientOrderId` must be provided.       |
+| \-origClientOrderId | \-STRING | \-NO\*    | \-Query order list by `listClientOrderId`. `orderListId` or `origClientOrderId` must be provided. |
+| \-recvWindow        | \-LONG   | \-NO      | \-The value cannot be greater than `60000`                                                        |
+| \-timestamp         | \-LONG   | \-YES     |                                                                                                   |
+
+**Data Source:** Database
+
+**Response:**
+
+```json
+{
+  "orderListId": 27,
+  "contingencyType": "OCO",
+  "listStatusType": "EXEC_STARTED",
+  "listOrderStatus": "EXECUTING",
+  "listClientOrderId": "h2USkA5YQpaXHPIrkd96xE",
+  "transactionTime": 1565245656253,
+  "symbol": "LTCBTC",
+  "orders": [
+    {
+      "symbol": "LTCBTC",
+      "orderId": 4,
+      "clientOrderId": "qD1gy3kc3Gx0rihm9Y3xwS"
+    },
+    {
+      "symbol": "LTCBTC",
+      "orderId": 5,
+      "clientOrderId": "ARzZ9I00CPM8i3NhmU9Ega"
+    }
+  ]
+}
+```
+
+#### Query all Order lists (USER_DATA)
+
+```null
+GET /api/v3/allOrderList
+```
+
+Retrieves all order lists based on provided optional parameters.
+
+Note that the time between `startTime` and `endTime` can't be longer than 24
+hours.
+
+**Weight:** 20
+
+**Parameters:**
+
+| Name         | Type   | Mandatory | Description                                                     |
+| ------------ | ------ | --------- | --------------------------------------------------------------- |
+| \-fromId     | \-LONG | \-NO      | \-If supplied, neither `startTime` or `endTime` can be provided |
+| \-startTime  | \-LONG | \-NO      |                                                                 |
+| \-endTime    | \-LONG | \-NO      |                                                                 |
+| \-limit      | \-INT  | \-NO      | \-Default: 500; Maximum: 1000                                   |
+| \-recvWindow | \-LONG | \-NO      | \-The value cannot be greater than `60000`                      |
+| \-timestamp  | \-LONG | \-YES     |                                                                 |
+
+**Data Source:** Database
+
+**Response:**
+
+```json
+[
+  {
+    "orderListId": 29,
+    "contingencyType": "OCO",
+    "listStatusType": "EXEC_STARTED",
+    "listOrderStatus": "EXECUTING",
+    "listClientOrderId": "amEEAXryFzFwYF1FeRpUoZ",
+    "transactionTime": 1565245913483,
+    "symbol": "LTCBTC",
+    "orders": [
+      {
+        "symbol": "LTCBTC",
+        "orderId": 4,
+        "clientOrderId": "oD7aesZqjEGlZrbtRpy5zB"
+      },
+      {
+        "symbol": "LTCBTC",
+        "orderId": 5,
+        "clientOrderId": "Jr1h6xirOxgeJOUuYQS7V3"
+      }
+    ]
+  },
+  {
+    "orderListId": 28,
+    "contingencyType": "OCO",
+    "listStatusType": "EXEC_STARTED",
+    "listOrderStatus": "EXECUTING",
+    "listClientOrderId": "hG7hFNxJV6cZy3Ze4AUT4d",
+    "transactionTime": 1565245913407,
+    "symbol": "LTCBTC",
+    "orders": [
+      {
+        "symbol": "LTCBTC",
+        "orderId": 2,
+        "clientOrderId": "j6lFOfbmFMRjTYA7rRJ0LP"
+      },
+      {
+        "symbol": "LTCBTC",
+        "orderId": 3,
+        "clientOrderId": "z0KCjOdditiLS5ekAFtK81"
+      }
+    ]
+  }
+]
+```
+
+#### Query Open Order lists (USER_DATA)
+
+```null
+GET /api/v3/openOrderList
+```
+
+**Weight:** 6
+
+**Parameters:**
+
+| Name         | Type   | Mandatory | Description                                |
+| ------------ | ------ | --------- | ------------------------------------------ |
+| \-recvWindow | \-LONG | \-NO      | \-The value cannot be greater than `60000` |
+| \-timestamp  | \-LONG | \-YES     |                                            |
+
+**Data Source:** Database
+
+**Response:**
+
+```json
+[
+  {
+    "orderListId": 31,
+    "contingencyType": "OCO",
+    "listStatusType": "EXEC_STARTED",
+    "listOrderStatus": "EXECUTING",
+    "listClientOrderId": "wuB13fmulKj3YjdqWEcsnp",
+    "transactionTime": 1565246080644,
+    "symbol": "LTCBTC",
+    "orders": [
+      {
+        "symbol": "LTCBTC",
+        "orderId": 4,
+        "clientOrderId": "r3EH2N76dHfLoSZWIUw1bT"
+      },
+      {
+        "symbol": "LTCBTC",
+        "orderId": 5,
+        "clientOrderId": "Cv1SnyPD3qhqpbjpYEHbd2"
+      }
+    ]
+  }
+]
 ```
 
 #### Account trade list (USER_DATA)

--- a/docs/binance/spot/private_websocket_api.md
+++ b/docs/binance/spot/private_websocket_api.md
@@ -1658,7 +1658,7 @@ To apply an event to your local order book, follow this update procedure:
   disconnected after the 24-hour mark.
 - Responses are in JSON by default. To receive responses in SBE, refer to the
   [SBE FAQ](/docs/binance-spot-api-docs/faqs/sbe_faq) page.
-- The WebSocket server will send a `ping frame` every 20 seconds.\`
+- The WebSocket server will send a `ping frame` every 20 seconds.
   - If the WebSocket server does not receive a `pong frame` back from the
     connection within a minute the connection will be disconnected.
   - When you receive a ping, you must send a pong with a copy of ping's payload
@@ -1669,7 +1669,7 @@ To apply an event to your local order book, follow this update procedure:
 - All timestamps in the JSON responses are in **milliseconds in UTC by
   default**. To receive the information in microseconds, please add the
   parameter `timeUnit=MICROSECOND` or `timeUnit=microsecond` in the URL.
-- Timestamp parameters (e.g. `startTime`, `endTime`, `timestamp)` can be passed
+- Timestamp parameters (e.g. `startTime`, `endTime`, `timestamp`) can be passed
   in milliseconds or microseconds.
 - All field names and values are **case-sensitive**, unless noted otherwise.
 - If there are enums or terms you want clarification on, please see
@@ -1858,7 +1858,7 @@ error codes and messages.
 User Data Stream events for non-SBE sessions are sent as JSON in **text
 frames**, one event per frame.
 
-Events in SBE sessions will be sent as **binary frames.**
+Events in SBE sessions will be sent as **binary frames**.
 
 Please refer to
 [`userDataStream.subscribe`](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user_data_stream_subscribe)
@@ -3217,99 +3217,6 @@ With `computeCommissionRates`:
 }
 ```
 
-#### Query order (USER_DATA)
-
-```json
-{
-  "id": "aa62318a-5a97-4f3b-bdc7-640bbe33b291",
-  "method": "order.status",
-  "params": {
-    "symbol": "BTCUSDT",
-    "orderId": 12569099453,
-    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
-    "signature": "2c3aab5a078ee4ea465ecd95523b77289f61476c2f238ec10c55ea6cb11a6f35",
-    "timestamp": 1660801720951
-  }
-}
-```
-
-Check execution status of an order.
-
-**Weight:** 4
-
-**Parameters:**
-
-| Name                  | Type     | Mandatory                         | Description                              |
-| --------------------- | -------- | --------------------------------- | ---------------------------------------- |
-| \-`symbol`            | \-STRING | \-YES                             |                                          |
-| \-`orderId`           | \-INT    | \-YES                             | \-Lookup order by `orderId`              |
-| \-`origClientOrderId` | \-STRING | \-Lookup order by `clientOrderId` |
-| \-`apiKey`            | \-STRING | \-YES                             |                                          |
-| \-`recvWindow`        | \-LONG   | \-NO                              | \-The value cannot be greater than 60000 |
-| \-`signature`         | \-STRING | \-YES                             |                                          |
-| \-`timestamp`         | \-LONG   | \-YES                             |                                          |
-
-Notes:
-
-- If both `orderId` and `origClientOrderId` are provided, the `orderId` is
-  searched first, then the `origClientOrderId` from that result is checked
-  against that order. If both conditions are not met the request will be
-  rejected.
-- For some historical orders the `cummulativeQuoteQty` response field may be
-  negative, meaning the data is not available at this time.
-
-**Data Source:** Memory => Database
-
-**Response:**
-
-```json
-{
-  "id": "aa62318a-5a97-4f3b-bdc7-640bbe33b291",
-  "status": 200,
-  "result": {
-    "symbol": "BTCUSDT",
-    "orderId": 12569099453,
-    "orderListId": -1, // set only for orders of an order list
-    "clientOrderId": "4d96324ff9d44481926157",
-    "price": "23416.10000000",
-    "origQty": "0.00847000",
-    "executedQty": "0.00847000",
-    "cummulativeQuoteQty": "198.33521500",
-    "status": "FILLED",
-    "timeInForce": "GTC",
-    "type": "LIMIT",
-    "side": "SELL",
-    "stopPrice": "0.00000000", // always present, zero if order type does not use stopPrice
-    "trailingDelta": 10, // present only if trailingDelta set for the order
-    "trailingTime": -1, // present only if trailingDelta set for the order
-    "icebergQty": "0.00000000", // always present, zero for non-iceberg orders
-    "time": 1660801715639, // time when the order was placed
-    "updateTime": 1660801717945, // time of the last update to the order
-    "isWorking": true,
-    "workingTime": 1660801715639,
-    "origQuoteOrderQty": "0.00000000", // always present, zero if order type does not use quoteOrderQty
-    "strategyId": 37463720, // present only if strategyId set for the order
-    "strategyType": 1000000, // present only if strategyType set for the order
-    "selfTradePreventionMode": "NONE",
-    "preventedMatchId": 0, // present only if the order expired due to STP
-    "preventedQuantity": "1.200000" // present only if the order expired due to STP
-  },
-  "rateLimits": [
-    {
-      "rateLimitType": "REQUEST_WEIGHT",
-      "interval": "MINUTE",
-      "intervalNum": 1,
-      "limit": 6000,
-      "count": 4
-    }
-  ]
-}
-```
-
-**Note:** The payload above does not show all fields that can appear. Please
-refer to
-[Conditional fields in Order Responses](/docs/binance-spot-api-docs/websocket-api/trading-requests#conditional-fields-in-order-responses).
-
 #### Cancel order (TRADE)
 
 ```json
@@ -3429,7 +3336,7 @@ When an order list is canceled:
         "clientOrderId": "Tnu2IP0J5Y4mxw3IATBfmW"
       }
     ],
-    //order list's leg status format is the same as for individual orders.
+    //order list order's status format is the same as for individual orders.
     "orderReports": [
       {
         "symbol": "BTCUSDT",
@@ -3460,6 +3367,7 @@ When an order list is canceled:
         "price": "23400.00000000",
         "origQty": "0.00850000",
         "executedQty": "0.00000000",
+        "origQuoteOrderQty": "0.000000",
         "cummulativeQuoteQty": "0.00000000",
         "status": "CANCELED",
         "timeInForce": "GTC",
@@ -3577,8 +3485,7 @@ Values smaller than 1000000 are reserved and cannot be used.
 
 The allowed enums is dependent on what is configured on the symbol.
 
-The possible supported values are EXPIRE_TAKER, EXPIRE_MAKER, EXPIRE_BOTH, NONE,
-DECREMENT.
+Supported values: [STP Modes](/docs/binance-spot-api-docs/enums.md#stpmodes).
 
 | | \-`cancelRestrictions` | \-ENUM | \-NO | \-Supported values: `ONLY_NEW` -
 Cancel will succeed if the order status is `NEW`. `ONLY_PARTIALLY_FILLED` -
@@ -3666,7 +3573,7 @@ Notes:
 - Like
   [`order.cancel`](/docs/binance-spot-api-docs/websocket-api/trading-requests#cancel-order-trade),
   if you cancel an individual order from an order list, the entire order list is
-  cancelled.
+  canceled.
 - The performance for canceling an order (single cancel or as part of a
   cancel-replace) is always better when only `orderId` is sent. Sending
   `origClientOrderId` or both `orderId` + `origClientOrderId` will be slower.
@@ -4227,105 +4134,6 @@ Response for an order which is part of an Order list:
 refer to
 [Conditional fields in Order Responses](/docs/binance-spot-api-docs/websocket-api/trading-requests#conditional-fields-in-order-responses).
 
-#### Current open orders (USER_DATA)
-
-```json
-{
-  "id": "55f07876-4f6f-4c47-87dc-43e5fff3f2e7",
-  "method": "openOrders.status",
-  "params": {
-    "symbol": "BTCUSDT",
-    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
-    "signature": "d632b3fdb8a81dd44f82c7c901833309dd714fe508772a89b0a35b0ee0c48b89",
-    "timestamp": 1660813156812
-  }
-}
-```
-
-Query execution status of all open orders.
-
-If you need to continuously monitor order status updates, please consider using
-WebSocket Streams:
-
-- [`userDataStream.start`](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user-data-stream-requests)
-  request
-- [`executionReport`](/docs/binance-spot-api-docs/user-data-stream#order-update)
-  user data stream event
-
-**Weight:** Adjusted based on the number of requested symbols:
-
-| Parameter  | Weight |
-| ---------- | ------ |
-| \-`symbol` | \-6    |
-| \-none     | \-80   |
-
-**Parameters:**
-
-| Name           | Type     | Mandatory | Description                                            |
-| -------------- | -------- | --------- | ------------------------------------------------------ |
-| \-`symbol`     | \-STRING | \-NO      | \-If omitted, open orders for all symbols are returned |
-| \-`apiKey`     | \-STRING | \-YES     |                                                        |
-| \-`recvWindow` | \-LONG   | \-NO      | \-The value cannot be greater than `60000`             |
-| \-`signature`  | \-STRING | \-YES     |                                                        |
-| \-`timestamp`  | \-LONG   | \-YES     |                                                        |
-
-**Data Source:** Memory => Database
-
-**Response:**
-
-Status reports for open orders are identical to
-[`order.status`](/docs/binance-spot-api-docs/websocket-api/trading-requests#query-order-user_data).
-
-Note that some fields are optional and included only for orders that set them.
-
-Open orders are always returned as a flat list. If all symbols are requested,
-use the `symbol` field to tell which symbol the orders belong to.
-
-```json
-{
-  "id": "55f07876-4f6f-4c47-87dc-43e5fff3f2e7",
-  "status": 200,
-  "result": [
-    {
-      "symbol": "BTCUSDT",
-      "orderId": 12569099453,
-      "orderListId": -1,
-      "clientOrderId": "4d96324ff9d44481926157",
-      "price": "23416.10000000",
-      "origQty": "0.00847000",
-      "executedQty": "0.00720000",
-      "origQuoteOrderQty": "0.000000",
-      "cummulativeQuoteQty": "172.43931000",
-      "status": "PARTIALLY_FILLED",
-      "timeInForce": "GTC",
-      "type": "LIMIT",
-      "side": "SELL",
-      "stopPrice": "0.00000000",
-      "icebergQty": "0.00000000",
-      "time": 1660801715639,
-      "updateTime": 1660801717945,
-      "isWorking": true,
-      "workingTime": 1660801715639,
-      "origQuoteOrderQty": "0.00000000",
-      "selfTradePreventionMode": "NONE"
-    }
-  ],
-  "rateLimits": [
-    {
-      "rateLimitType": "REQUEST_WEIGHT",
-      "interval": "MINUTE",
-      "intervalNum": 1,
-      "limit": 6000,
-      "count": 6
-    }
-  ]
-}
-```
-
-**Note:** The payload above does not show all fields that can appear. Please
-refer to
-[Conditional fields in Order Responses](/docs/binance-spot-api-docs/websocket-api/trading-requests#conditional-fields-in-order-responses).
-
 #### Cancel open orders (TRADE)
 
 ```json
@@ -4702,7 +4510,7 @@ for more examples.
 }
 ```
 
-Send in an one-cancels the other (OCO) pair, where activation of one order
+Send in an one-cancels-the-other (OCO) pair, where activation of one order
 immediately cancels the other.
 
 - An OCO has 2 orders called the **above order** and **below order**.
@@ -4738,7 +4546,7 @@ immediately cancels the other.
 | \-`aboveClientOrderId`      | \-STRING  | \-NO      | \-Arbitrary unique ID among open orders for the above order. Automatically generated if not sent                                                                                                                                                                                                          |
 | \-`aboveIcebergQty`         | \-LONG    | \-NO      | \-Note that this can only be used if `aboveTimeInForce` is `GTC`.                                                                                                                                                                                                                                         |
 | \-`abovePrice`              | \-DECIMAL | \-NO      | \-Can be used if `aboveType` is `STOP_LOSS_LIMIT` , `LIMIT_MAKER`, or `TAKE_PROFIT_LIMIT` to specify the limit price.                                                                                                                                                                                     |
-| \-`aboveStopPrice`          | \-DECIMAL | \-NO      | \-Can be used if `aboveType` is `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, `TAKE_PROFIT_LIMIT` Either `aboveStopPrice` or `aboveTrailingDelta` or both, must be specified.                                                                                                                            |
+| \-`aboveStopPrice`          | \-DECIMAL | \-NO      | \-Can be used if `aboveType` is `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`, `TAKE_PROFIT_LIMIT`. Either `aboveStopPrice` or `aboveTrailingDelta` or both, must be specified.                                                                                                                           |
 | \-`aboveTrailingDelta`      | \-LONG    | \-NO      | \-See [Trailing Stop order FAQ](/docs/binance-spot-api-docs/faqs/trailing-stop-faq).                                                                                                                                                                                                                      |
 | \-`aboveTimeInForce`        | \-DECIMAL | \-NO      | \-Required if `aboveType` is `STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT`.                                                                                                                                                                                                                                    |
 | \-`aboveStrategyId`         | \-LONG    | \-NO      | \-Arbitrary numeric value identifying the above order within an order strategy.                                                                                                                                                                                                                           |
@@ -4747,7 +4555,7 @@ immediately cancels the other.
 | \-`belowClientOrderId`      | \-STRING  | \-NO      |                                                                                                                                                                                                                                                                                                           |
 | \-`belowIcebergQty`         | \-LONG    | \-NO      | \-Note that this can only be used if `belowTimeInForce` is `GTC`.                                                                                                                                                                                                                                         |
 | \-`belowPrice`              | \-DECIMAL | \-NO      | \-Can be used if `belowType` is `STOP_LOSS_LIMIT` , `LIMIT_MAKER`, or `TAKE_PROFIT_LIMIT` to specify the limit price.                                                                                                                                                                                     |
-| \-`belowStopPrice`          | \-DECIMAL | \-NO      | \-Can be used if `belowType` is `STOP_LOSS`, `STOP_LOSS_LIMIT, TAKE_PROFIT` or `TAKE_PROFIT_LIMIT`. Either `belowStopPrice` or `belowTrailingDelta` or both, must be specified.                                                                                                                           |
+| \-`belowStopPrice`          | \-DECIMAL | \-NO      | \-Can be used if `belowType` is `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT` or `TAKE_PROFIT_LIMIT`. Either `belowStopPrice` or `belowTrailingDelta` or both, must be specified.                                                                                                                         |
 | \-`belowTrailingDelta`      | \-LONG    | \-NO      | \-See [Trailing Stop order FAQ](/docs/binance-spot-api-docs/faqs/trailing-stop-faq).                                                                                                                                                                                                                      |
 | \-`belowTimeInForce`        | \-ENUM    | \-NO      | \-Required if `belowType` is `STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT`                                                                                                                                                                                                                                     |
 | \-`belowStrategyId`         | \-LONG    | \-NO      | \-Arbitrary numeric value identifying the below order within an order strategy.                                                                                                                                                                                                                           |
@@ -4892,6 +4700,10 @@ Places an OTO.
   is only placed on the order book when the working order gets **fully filled**.
 - If either the working order or the pending order is cancelled individually,
   the other order in the order list will also be canceled or expired.
+- When the order list is placed, if the working order gets **immediately fully
+  filled**, the placement response will show the working order as `FILLED` but
+  the pending order will still appear as `PENDING_NEW`. You need to query the
+  status of the pending order again to see its updated status.
 - OTOs add **2 orders** to the `EXCHANGE_MAX_NUM_ORDERS` filter and
   `MAX_NUM_ORDERS` filter.
 
@@ -4905,26 +4717,26 @@ Places an OTO.
 | --------------------------- | --------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | \-`symbol`                  | \-STRING  | \-YES     |                                                                                                                                                                                                                                                                                                             |
 | \-`listClientOrderId`       | \-STRING  | \-NO      | \-Arbitrary unique ID among open order lists. Automatically generated if not sent. A new order list with the same listClientOrderId is accepted only when the previous one is filled or completely expired. `listClientOrderId` is distinct from the `workingClientOrderId` and the `pendingClientOrderId`. |
-| \-`newOrderRespType`        | \-ENUM    | \-NO      | \-Format of the JSON response. Supported values: [Order Response Type](/docs/binance-spot-api-docs/enums#order-response-type-neworderresptype)                                                                                                                                                              |
-| \-`selfTradePreventionMode` | \-ENUM    | \-NO      | \-The allowed values are dependent on what is configured on the symbol. See [STP Modes](/docs/binance-spot-api-docs/enums#stp-modes)                                                                                                                                                                        |
+| \-`newOrderRespType`        | \-ENUM    | \-NO      | \-Format of the JSON response. Supported values: [Order Response Type](/docs/binance-spot-api-docs/enums#orderresponsetype)                                                                                                                                                                                 |
+| \-`selfTradePreventionMode` | \-ENUM    | \-NO      | \-The allowed values are dependent on what is configured on the symbol. Supported values: [STP Modes](/docs/binance-spot-api-docs/enums#stpmodes)                                                                                                                                                           |
 | \-`workingType`             | \-ENUM    | \-YES     | \-Supported values: `LIMIT`,`LIMIT_MAKER`                                                                                                                                                                                                                                                                   |
-| \-`workingSide`             | \-ENUM    | \-YES     | \-Supported values: [Order Side](/docs/binance-spot-api-docs/enums#order-side-side)                                                                                                                                                                                                                         |
+| \-`workingSide`             | \-ENUM    | \-YES     | \-Supported values: [Order side](/docs/binance-spot-api-docs/enums#side)                                                                                                                                                                                                                                    |
 | \-`workingClientOrderId`    | \-STRING  | \-NO      | \-Arbitrary unique ID among open orders for the working order. Automatically generated if not sent.                                                                                                                                                                                                         |
 | \-`workingPrice`            | \-DECIMAL | \-YES     |                                                                                                                                                                                                                                                                                                             |
 | \-`workingQuantity`         | \-DECIMAL | \-YES     | \-Sets the quantity for the working order.                                                                                                                                                                                                                                                                  |
 | \-`workingIcebergQty`       | \-DECIMAL | \-NO      | \-This can only be used if `workingTimeInForce` is `GTC`, or if `workingType` is `LIMIT_MAKER`.                                                                                                                                                                                                             |
-| \-`workingTimeInForce`      | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/websocket-api/trading-requests#timeInForce)                                                                                                                                                                                                 |
+| \-`workingTimeInForce`      | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/enums#timeinforce)                                                                                                                                                                                                                          |
 | \-`workingStrategyId`       | \-LONG    | \-NO      | \-Arbitrary numeric value identifying the working order within an order strategy.                                                                                                                                                                                                                           |
 | \-`workingStrategyType`     | \-INT     | \-NO      | \-Arbitrary numeric value identifying the working order strategy. Values smaller than 1000000 are reserved and cannot be used.                                                                                                                                                                              |
-| \-`pendingType`             | \-ENUM    | \-YES     | \-Supported values: [Order Types](/docs/binance-spot-api-docs/websocket-api/trading-requests#order-type) Note that `MARKET` orders using `quoteOrderQty` are not supported.                                                                                                                                 |
-| \-`pendingSide`             | \-ENUM    | \-YES     | \-Supported values: [Order Side](/docs/binance-spot-api-docs/enums#order-side-side)                                                                                                                                                                                                                         |
+| \-`pendingType`             | \-ENUM    | \-YES     | \-Supported values: [Order types](/docs/binance-spot-api-docs/websocket-api/trading-requests#order-type). Note that `MARKET` orders using `quoteOrderQty` are not supported.                                                                                                                                |
+| \-`pendingSide`             | \-ENUM    | \-YES     | \-Supported values: [Order side](/docs/binance-spot-api-docs/enums#side)                                                                                                                                                                                                                                    |
 | \-`pendingClientOrderId`    | \-STRING  | \-NO      | \-Arbitrary unique ID among open orders for the pending order. Automatically generated if not sent.                                                                                                                                                                                                         |
 | \-`pendingPrice`            | \-DECIMAL | \-NO      |                                                                                                                                                                                                                                                                                                             |
 | \-`pendingStopPrice`        | \-DECIMAL | \-NO      |                                                                                                                                                                                                                                                                                                             |
 | \-`pendingTrailingDelta`    | \-DECIMAL | \-NO      |                                                                                                                                                                                                                                                                                                             |
 | \-`pendingQuantity`         | \-DECIMAL | \-YES     | \-Sets the quantity for the pending order.                                                                                                                                                                                                                                                                  |
 | \-`pendingIcebergQty`       | \-DECIMAL | \-NO      | \-This can only be used if `pendingTimeInForce` is `GTC`, or if `pendingType` is `LIMIT_MAKER`.                                                                                                                                                                                                             |
-| \-`pendingTimeInForce`      | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/websocket-api/trading-requests#timeInForce)                                                                                                                                                                                                 |
+| \-`pendingTimeInForce`      | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/enums#timeinforce)                                                                                                                                                                                                                          |
 | \-`pendingStrategyId`       | \-LONG    | \-NO      | \-Arbitrary numeric value identifying the pending order within an order strategy.                                                                                                                                                                                                                           |
 | \-`pendingStrategyType`     | \-INT     | \-NO      | \-Arbitrary numeric value identifying the pending order strategy. Values smaller than 1000000 are reserved and cannot be used.                                                                                                                                                                              |
 | \-`recvWindow`              | \-LONG    | \-NO      | \-The value cannot be greater than `60000`.                                                                                                                                                                                                                                                                 |
@@ -4936,12 +4748,12 @@ Places an OTO.
 Depending on the `pendingType` or `workingType`, some optional parameters will
 become mandatory.
 
-| Type                                                      | Additional mandatory parameters                                          | Additional information |
-| --------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------- |
-| \-`workingType` = `LIMIT`                                 | \-`workingTimeInForce`                                                   |                        |
-| \-`pendingType`\= `LIMIT`                                 | \-`pendingPrice`, `pendingTimeInForce`                                   |                        |
-| \-`pendingType`\= `STOP_LOSS` or `TAKE_PROFIT`            | \-`pendingStopPrice` and/or `pendingTrailingDelta`                       |                        |
-| \-`pendingType`\=`STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT` | \-`pendingStopPrice` and/or `pendingTrailingDelta`, `pendingTimeInForce` |                        |
+| Type                                                      | Additional mandatory parameters                                                          | Additional information |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------- |
+| \-`workingType` = `LIMIT`                                 | \-`workingTimeInForce`                                                                   |                        |
+| \-`pendingType` = `LIMIT`                                 | \-`pendingPrice`, `pendingTimeInForce`                                                   |                        |
+| \-`pendingType` = `STOP_LOSS` or `TAKE_PROFIT`            | \-`pendingStopPrice` and/or `pendingTrailingDelta`                                       |                        |
+| \-`pendingType` =`STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT` | \-`pendingPrice`, `pendingStopPrice` and/or `pendingTrailingDelta`, `pendingTimeInForce` |                        |
 
 **Data Source:**
 
@@ -5073,6 +4885,9 @@ Place an OTOCO.
 - OTOCO has 2 pending orders (pending above and pending below), forming an OCO
   pair. The pending orders are only placed on the order book when the working
   order gets **fully filled**.
+  - The rules of the pending above and pending below follow the same rules as
+    the
+    [Order list OCO](/docs/binance-spot-api-docs/websocket-api/trading-requests#new-order-list---oco-trade).
 - OTOCOs add **3 orders** to the `EXCHANGE_MAX_NUM_ORDERS` filter and
   `MAX_NUM_ORDERS` filter.
 
@@ -5086,15 +4901,15 @@ Place an OTOCO.
 | ----------------------------- | --------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | \-`symbol`                    | \-STRING  | \-YES     |                                                                                                                                                                                                                                                                                                                                                |
 | \-`listClientOrderId`         | \-STRING  | \-NO      | \-Arbitrary unique ID among open order lists. Automatically generated if not sent. A new order list with the same listClientOrderId is accepted only when the previous one is filled or completely expired. `listClientOrderId` is distinct from the `workingClientOrderId`, `pendingAboveClientOrderId`, and the `pendingBelowClientOrderId`. |
-| \-`newOrderRespType`          | \-ENUM    | \-NO      | \-Format the JSON response. Supported values: [Order Response Type](/docs/binance-spot-api-docs/enums#order-response-type-neworderresptype)                                                                                                                                                                                                    |
-| \-`selfTradePreventionMode`   | \-ENUM    | \-NO      | \-The allowed values are dependent on what is configured on the symbol. See [STP Modes](/docs/binance-spot-api-docs/enums#stpmodes)                                                                                                                                                                                                            |
+| \-`newOrderRespType`          | \-ENUM    | \-NO      | \-Format of the JSON response. Supported values: [Order Response Type](/docs/binance-spot-api-docs/enums#orderresponsetype)                                                                                                                                                                                                                    |
+| \-`selfTradePreventionMode`   | \-ENUM    | \-NO      | \-The allowed values are dependent on what is configured on the symbol. Supported values: [STP Modes](/docs/binance-spot-api-docs/enums#stpmodes)                                                                                                                                                                                              |
 | \-`workingType`               | \-ENUM    | \-YES     | \-Supported values: `LIMIT`, `LIMIT_MAKER`                                                                                                                                                                                                                                                                                                     |
 | \-`workingSide`               | \-ENUM    | \-YES     | \-Supported values: [Order Side](/docs/binance-spot-api-docs/enums#side)                                                                                                                                                                                                                                                                       |
 | \-`workingClientOrderId`      | \-STRING  | \-NO      | \-Arbitrary unique ID among open orders for the working order. Automatically generated if not sent.                                                                                                                                                                                                                                            |
 | \-`workingPrice`              | \-DECIMAL | \-YES     |                                                                                                                                                                                                                                                                                                                                                |
 | \-`workingQuantity`           | \-DECIMAL | \-YES     |                                                                                                                                                                                                                                                                                                                                                |
 | \-`workingIcebergQty`         | \-DECIMAL | \-NO      | \-This can only be used if `workingTimeInForce` is `GTC`.                                                                                                                                                                                                                                                                                      |
-| \-`workingTimeInForce`        | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/websocket-api/trading-requests#timeInForce)                                                                                                                                                                                                                                    |
+| \-`workingTimeInForce`        | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/enums#timeinforce)                                                                                                                                                                                                                                                             |
 | \-`workingStrategyId`         | \-LONG    | \-NO      | \-Arbitrary numeric value identifying the working order within an order strategy.                                                                                                                                                                                                                                                              |
 | \-`workingStrategyType`       | \-INT     | \-NO      | \-Arbitrary numeric value identifying the working order strategy. Values smaller than 1000000 are reserved and cannot be used.                                                                                                                                                                                                                 |
 | \-`pendingSide`               | \-ENUM    | \-YES     | \-Supported values: [Order Side](/docs/binance-spot-api-docs/enums#side)                                                                                                                                                                                                                                                                       |
@@ -5110,11 +4925,11 @@ Place an OTOCO.
 | \-`pendingAboveStrategyType`  | \-INT     | \-NO      | \-Arbitrary numeric value identifying the pending above order strategy. Values smaller than 1000000 are reserved and cannot be used.                                                                                                                                                                                                           |
 | \-`pendingBelowType`          | \-ENUM    | \-NO      | \-Supported values: `STOP_LOSS`, `STOP_LOSS_LIMIT`, `TAKE_PROFIT`,`TAKE_PROFIT_LIMIT`                                                                                                                                                                                                                                                          |
 | \-`pendingBelowClientOrderId` | \-STRING  | \-NO      | \-Arbitrary unique ID among open orders for the pending below order. Automatically generated if not sent.                                                                                                                                                                                                                                      |
-| \-`pendingBelowPrice`         | \-DECIMAL | \-NO      | \-Can be used if `pendingBelowType` is `STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT` to specify limit price                                                                                                                                                                                                                                         |
+| \-`pendingBelowPrice`         | \-DECIMAL | \-NO      | \-Can be used if `pendingBelowType` is `STOP_LOSS_LIMIT` or `TAKE_PROFIT_LIMIT` to specify the limit price.                                                                                                                                                                                                                                    |
 | \-`pendingBelowStopPrice`     | \-DECIMAL | \-NO      | \-Can be used if `pendingBelowType` is `STOP_LOSS`, `STOP_LOSS_LIMIT, TAKE_PROFIT or TAKE_PROFIT_LIMIT`. Either `pendingBelowStopPrice` or `pendingBelowTrailingDelta` or both, must be specified.                                                                                                                                             |
 | \-`pendingBelowTrailingDelta` | \-DECIMAL | \-NO      |                                                                                                                                                                                                                                                                                                                                                |
 | \-`pendingBelowIcebergQty`    | \-DECIMAL | \-NO      | \-This can only be used if `pendingBelowTimeInForce` is `GTC`, or if `pendingBelowType` is `LIMIT_MAKER`.                                                                                                                                                                                                                                      |
-| \-`pendingBelowTimeInForce`   | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/websocket-api/trading-requests#timeInForce)                                                                                                                                                                                                                                    |
+| \-`pendingBelowTimeInForce`   | \-ENUM    | \-NO      | \-Supported values: [Time In Force](/docs/binance-spot-api-docs/enums#timeinforce)                                                                                                                                                                                                                                                             |
 | \-`pendingBelowStrategyId`    | \-LONG    | \-NO      | \-Arbitrary numeric value identifying the pending below order within an order strategy.                                                                                                                                                                                                                                                        |
 | \-`pendingBelowStrategyType`  | \-INT     | \-NO      | \-Arbitrary numeric value identifying the pending below order strategy. Values smaller than 1000000 are reserved and cannot be used.                                                                                                                                                                                                           |
 | \-`recvWindow`                | \-LONG    | \-NO      | \-The value cannot be greater than `60000`.                                                                                                                                                                                                                                                                                                    |
@@ -5251,86 +5066,6 @@ optional parameters will become mandatory.
 refer to
 [Conditional fields in Order Responses](/docs/binance-spot-api-docs/websocket-api/trading-requests#conditional-fields-in-order-responses).
 
-##### Query Order list (USER_DATA)
-
-```json
-{
-  "id": "b53fd5ff-82c7-4a04-bd64-5f9dc42c2100",
-  "method": "orderList.status",
-  "params": {
-    "origClientOrderId": "08985fedd9ea2cf6b28996",
-    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
-    "signature": "d12f4e8892d46c0ddfbd43d556ff6d818581b3be22a02810c2c20cb719aed6a4",
-    "timestamp": 1660801713965
-  }
-}
-```
-
-Check execution status of an Order list.
-
-For execution status of individual orders, use
-[`order.status`](/docs/binance-spot-api-docs/websocket-api/trading-requests#query-order-user_data).
-
-**Weight:** 4
-
-**Parameters**:
-
-| Name                  | Type     | Mandatory                                                                                  | Description                                                                                      |
-| --------------------- | -------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| \-`origClientOrderId` | \-STRING | \-NO\*                                                                                     | \-Query order list by `listClientOrderId`.`orderListId` or `origClientOrderId` must be provided. |
-| \-`orderListId`       | \-INT    | \-Query order list by `orderListId`.`orderListId` or `origClientOrderId` must be provided. |
-| \-`apiKey`            | \-STRING | \-YES                                                                                      |                                                                                                  |
-| \-`recvWindow`        | \-LONG   | \-NO                                                                                       | \-The value cannot be greater than 60000                                                         |
-| \-`signature`         | \-STRING | \-YES                                                                                      |                                                                                                  |
-| \-`timestamp`         | \-LONG   | \-YES                                                                                      |                                                                                                  |
-
-Notes:
-
-- `origClientOrderId` refers to `listClientOrderId` of the order list itself.
-- If both `origClientOrderId` and `orderListId` parameters are specified, only
-  `origClientOrderId` is used and `orderListId` is ignored.
-
-**Data Source:** Database
-
-**Response:**
-
-```json
-{
-  "id": "b53fd5ff-82c7-4a04-bd64-5f9dc42c2100",
-  "status": 200,
-  "result": {
-    "orderListId": 1274512,
-    "contingencyType": "OCO",
-    "listStatusType": "EXEC_STARTED",
-    "listOrderStatus": "EXECUTING",
-    "listClientOrderId": "08985fedd9ea2cf6b28996",
-    "transactionTime": 1660801713793,
-    "symbol": "BTCUSDT",
-    "orders": [
-      {
-        "symbol": "BTCUSDT",
-        "orderId": 12569138901,
-        "clientOrderId": "BqtFCj5odMoWtSqGk2X9tU"
-      },
-      {
-        "symbol": "BTCUSDT",
-        "orderId": 12569138902,
-        "clientOrderId": "jLnZpj5enfMXTuhKB1d0us"
-      }
-    ]
-  },
-  "rateLimits": [
-    {
-      "rateLimitType": "REQUEST_WEIGHT",
-      "interval": "MINUTE",
-      "intervalNum": 1,
-      "limit": 6000,
-      "count": 4
-    }
-  ]
-}
-```
-
 ##### Cancel Order list (TRADE)
 
 ```json
@@ -5366,9 +5101,11 @@ Cancel an active order list.
 
 Notes:
 
-- If both `orderListId` and `listClientOrderId` parameters are specified, only
-  `orderListId` is used and `listClientOrderId` is ignored.
-- Canceling an individual leg with
+- If both `orderListId` and `listClientOrderId` parameters are provided, the
+  `orderListId` is searched first, then the `listClientOrderId` from that result
+  is checked against that order. If both conditions are not met the request will
+  be rejected.
+- Canceling an individual order with
   [`order.cancel`](/docs/binance-spot-api-docs/websocket-api/trading-requests#cancel-order-trade)
   will cancel the entire order list as well.
 
@@ -5450,84 +5187,6 @@ Notes:
 }
 ```
 
-##### Current open Order lists (USER_DATA)
-
-```json
-{
-  "id": "3a4437e2-41a3-4c19-897c-9cadc5dce8b6",
-  "method": "openOrderLists.status",
-  "params": {
-    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
-    "signature": "1bea8b157dd78c3da30359bddcd999e4049749fe50b828e620e12f64e8b433c9",
-    "timestamp": 1660801713831
-  }
-}
-```
-
-Query execution status of all open order lists.
-
-If you need to continuously monitor order status updates, please consider using
-WebSocket Streams:
-
-- [`userDataStream.start`](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user-data-stream-requests)
-  request
-- [`executionReport`](/docs/binance-spot-api-docs/user-data-stream#order-update)
-  user data stream event
-
-**Weight**: 6
-
-**Parameters:**
-
-| Name           | Type     | Mandatory | Description                                |
-| -------------- | -------- | --------- | ------------------------------------------ |
-| \-`apiKey`     | \-STRING | \-YES     |                                            |
-| \-`recvWindow` | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
-| \-`signature`  | \-STRING | \-YES     |                                            |
-| \-`timestamp`  | \-LONG   | \-YES     |                                            |
-
-**Data Source:** Database
-
-**Response:**
-
-```json
-{
-  "id": "3a4437e2-41a3-4c19-897c-9cadc5dce8b6",
-  "status": 200,
-  "result": [
-    {
-      "orderListId": 0,
-      "contingencyType": "OCO",
-      "listStatusType": "EXEC_STARTED",
-      "listOrderStatus": "EXECUTING",
-      "listClientOrderId": "08985fedd9ea2cf6b28996",
-      "transactionTime": 1660801713793,
-      "symbol": "BTCUSDT",
-      "orders": [
-        {
-          "symbol": "BTCUSDT",
-          "orderId": 4,
-          "clientOrderId": "CUhLgTXnX5n2c0gWiLpV4d"
-        },
-        {
-          "symbol": "BTCUSDT",
-          "orderId": 5,
-          "clientOrderId": "1ZqG7bBuYwaF4SU8CwnwHm"
-        }
-      ]
-    }
-  ],
-  "rateLimits": [
-    {
-      "rateLimitType": "REQUEST_WEIGHT",
-      "interval": "MINUTE",
-      "intervalNum": 1,
-      "limit": 6000,
-      "count": 6
-    }
-  ]
-}
-```
-
 #### SOR
 
 ##### Place new order using SOR (TRADE)
@@ -5554,6 +5213,8 @@ Places an order using smart order routing (SOR).
 
 This adds 1 order to the `EXCHANGE_MAX_ORDERS` filter and the `MAX_NUM_ORDERS`
 filter.
+
+Read [SOR FAQ](/docs/faqs/sor_faq) to learn more.
 
 **Weight:** 1
 
@@ -5840,55 +5501,180 @@ Query information about your account.
 }
 ```
 
-#### Unfilled Order Count (USER_DATA)
+#### Query order (USER_DATA)
 
 ```json
 {
-  "id": "d3783d8d-f8d1-4d2c-b8a0-b7596af5a664",
-  "method": "account.rateLimits.orders",
+  "id": "aa62318a-5a97-4f3b-bdc7-640bbe33b291",
+  "method": "order.status",
   "params": {
+    "symbol": "BTCUSDT",
+    "orderId": 12569099453,
     "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
-    "signature": "76289424d6e288f4dc47d167ac824e859dabf78736f4348abbbac848d719eb94",
-    "timestamp": 1660801839500
+    "signature": "2c3aab5a078ee4ea465ecd95523b77289f61476c2f238ec10c55ea6cb11a6f35",
+    "timestamp": 1660801720951
   }
 }
 ```
 
-Query your current unfilled order count for all intervals.
+Check execution status of an order.
 
-**Weight:** 40
+**Weight:** 4
 
 **Parameters:**
 
-| Name           | Type     | Mandatory | Description                                |
-| -------------- | -------- | --------- | ------------------------------------------ |
-| \-`apiKey`     | \-STRING | \-YES     |                                            |
-| \-`recvWindow` | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
-| \-`signature`  | \-STRING | \-YES     |                                            |
-| \-`timestamp`  | \-LONG   | \-YES     |                                            |
+| Name                  | Type     | Mandatory                         | Description                              |
+| --------------------- | -------- | --------------------------------- | ---------------------------------------- |
+| \-`symbol`            | \-STRING | \-YES                             |                                          |
+| \-`orderId`           | \-INT    | \-YES                             | \-Lookup order by `orderId`              |
+| \-`origClientOrderId` | \-STRING | \-Lookup order by `clientOrderId` |
+| \-`apiKey`            | \-STRING | \-YES                             |                                          |
+| \-`recvWindow`        | \-LONG   | \-NO                              | \-The value cannot be greater than 60000 |
+| \-`signature`         | \-STRING | \-YES                             |                                          |
+| \-`timestamp`         | \-LONG   | \-YES                             |                                          |
 
-**Data Source:** Memory
+Notes:
+
+- If both `orderId` and `origClientOrderId` are provided, the `orderId` is
+  searched first, then the `origClientOrderId` from that result is checked
+  against that order. If both conditions are not met the request will be
+  rejected.
+- For some historical orders the `cummulativeQuoteQty` response field may be
+  negative, meaning the data is not available at this time.
+
+**Data Source:** Memory => Database
 
 **Response:**
 
 ```json
 {
-  "id": "d3783d8d-f8d1-4d2c-b8a0-b7596af5a664",
+  "id": "aa62318a-5a97-4f3b-bdc7-640bbe33b291",
+  "status": 200,
+  "result": {
+    "symbol": "BTCUSDT",
+    "orderId": 12569099453,
+    "orderListId": -1, // set only for orders of an order list
+    "clientOrderId": "4d96324ff9d44481926157",
+    "price": "23416.10000000",
+    "origQty": "0.00847000",
+    "executedQty": "0.00847000",
+    "cummulativeQuoteQty": "198.33521500",
+    "status": "FILLED",
+    "timeInForce": "GTC",
+    "type": "LIMIT",
+    "side": "SELL",
+    "stopPrice": "0.00000000", // always present, zero if order type does not use stopPrice
+    "trailingDelta": 10, // present only if trailingDelta set for the order
+    "trailingTime": -1, // present only if trailingDelta set for the order
+    "icebergQty": "0.00000000", // always present, zero for non-iceberg orders
+    "time": 1660801715639, // time when the order was placed
+    "updateTime": 1660801717945, // time of the last update to the order
+    "isWorking": true,
+    "workingTime": 1660801715639,
+    "origQuoteOrderQty": "0.00000000", // always present, zero if order type does not use quoteOrderQty
+    "strategyId": 37463720, // present only if strategyId set for the order
+    "strategyType": 1000000, // present only if strategyType set for the order
+    "selfTradePreventionMode": "NONE",
+    "preventedMatchId": 0, // present only if the order expired due to STP
+    "preventedQuantity": "1.200000" // present only if the order expired due to STP
+  },
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 6000,
+      "count": 4
+    }
+  ]
+}
+```
+
+**Note:** The payload above does not show all fields that can appear. Please
+refer to
+[Conditional fields in Order Responses](/docs/binance-spot-api-docs/websocket-api/trading-requests#conditional-fields-in-order-responses).
+
+#### Current open orders (USER_DATA)
+
+```json
+{
+  "id": "55f07876-4f6f-4c47-87dc-43e5fff3f2e7",
+  "method": "openOrders.status",
+  "params": {
+    "symbol": "BTCUSDT",
+    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
+    "signature": "d632b3fdb8a81dd44f82c7c901833309dd714fe508772a89b0a35b0ee0c48b89",
+    "timestamp": 1660813156812
+  }
+}
+```
+
+Query execution status of all open orders.
+
+If you need to continuously monitor order status updates, please consider using
+WebSocket Streams:
+
+- [`userDataStream.start`](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user-data-stream-requests)
+  request
+- [`executionReport`](/docs/binance-spot-api-docs/user-data-stream#order-update)
+  user data stream event
+
+**Weight:** Adjusted based on the number of requested symbols:
+
+| Parameter  | Weight |
+| ---------- | ------ |
+| \-`symbol` | \-6    |
+| \-none     | \-80   |
+
+**Parameters:**
+
+| Name           | Type     | Mandatory | Description                                            |
+| -------------- | -------- | --------- | ------------------------------------------------------ |
+| \-`symbol`     | \-STRING | \-NO      | \-If omitted, open orders for all symbols are returned |
+| \-`apiKey`     | \-STRING | \-YES     |                                                        |
+| \-`recvWindow` | \-LONG   | \-NO      | \-The value cannot be greater than `60000`             |
+| \-`signature`  | \-STRING | \-YES     |                                                        |
+| \-`timestamp`  | \-LONG   | \-YES     |                                                        |
+
+**Data Source:** Memory => Database
+
+**Response:**
+
+Status reports for open orders are identical to
+[`order.status`](/docs/binance-spot-api-docs/websocket-api/account-requests#query-order-user_data).
+
+Note that some fields are optional and included only for orders that set them.
+
+Open orders are always returned as a flat list. If all symbols are requested,
+use the `symbol` field to tell which symbol the orders belong to.
+
+```json
+{
+  "id": "55f07876-4f6f-4c47-87dc-43e5fff3f2e7",
   "status": 200,
   "result": [
     {
-      "rateLimitType": "ORDERS",
-      "interval": "SECOND",
-      "intervalNum": 10,
-      "limit": 50,
-      "count": 0
-    },
-    {
-      "rateLimitType": "ORDERS",
-      "interval": "DAY",
-      "intervalNum": 1,
-      "limit": 160000,
-      "count": 0
+      "symbol": "BTCUSDT",
+      "orderId": 12569099453,
+      "orderListId": -1,
+      "clientOrderId": "4d96324ff9d44481926157",
+      "price": "23416.10000000",
+      "origQty": "0.00847000",
+      "executedQty": "0.00720000",
+      "origQuoteOrderQty": "0.000000",
+      "cummulativeQuoteQty": "172.43931000",
+      "status": "PARTIALLY_FILLED",
+      "timeInForce": "GTC",
+      "type": "LIMIT",
+      "side": "SELL",
+      "stopPrice": "0.00000000",
+      "icebergQty": "0.00000000",
+      "time": 1660801715639,
+      "updateTime": 1660801717945,
+      "isWorking": true,
+      "workingTime": 1660801715639,
+      "origQuoteOrderQty": "0.00000000",
+      "selfTradePreventionMode": "NONE"
     }
   ],
   "rateLimits": [
@@ -5897,11 +5683,15 @@ Query your current unfilled order count for all intervals.
       "interval": "MINUTE",
       "intervalNum": 1,
       "limit": 6000,
-      "count": 40
+      "count": 6
     }
   ]
 }
 ```
+
+**Note:** The payload above does not show all fields that can appear. Please
+refer to
+[Conditional fields in Order Responses](/docs/binance-spot-api-docs/websocket-api/trading-requests#conditional-fields-in-order-responses).
 
 #### Account order history (USER_DATA)
 
@@ -6003,7 +5793,165 @@ Note that some fields are optional and included only for orders that set them.
 }
 ```
 
-#### Account Order list history (USER_DATA)
+#### Query Order list (USER_DATA)
+
+```json
+{
+  "id": "b53fd5ff-82c7-4a04-bd64-5f9dc42c2100",
+  "method": "orderList.status",
+  "params": {
+    "origClientOrderId": "08985fedd9ea2cf6b28996",
+    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
+    "signature": "d12f4e8892d46c0ddfbd43d556ff6d818581b3be22a02810c2c20cb719aed6a4",
+    "timestamp": 1660801713965
+  }
+}
+```
+
+Check execution status of an Order list.
+
+For execution status of individual orders, use
+[`order.status`](/docs/binance-spot-api-docs/websocket-api/account-requests#query-order-user_data).
+
+**Weight:** 4
+
+**Parameters**:
+
+| Name                  | Type     | Mandatory                                                                                  | Description                                                                                      |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| \-`origClientOrderId` | \-STRING | \-NO\*                                                                                     | \-Query order list by `listClientOrderId`.`orderListId` or `origClientOrderId` must be provided. |
+| \-`orderListId`       | \-INT    | \-Query order list by `orderListId`.`orderListId` or `origClientOrderId` must be provided. |
+| \-`apiKey`            | \-STRING | \-YES                                                                                      |                                                                                                  |
+| \-`recvWindow`        | \-LONG   | \-NO                                                                                       | \-The value cannot be greater than 60000                                                         |
+| \-`signature`         | \-STRING | \-YES                                                                                      |                                                                                                  |
+| \-`timestamp`         | \-LONG   | \-YES                                                                                      |                                                                                                  |
+
+Notes:
+
+- `origClientOrderId` refers to `listClientOrderId` of the order list itself.
+- If both `origClientOrderId` and `orderListId` parameters are specified, only
+  `origClientOrderId` is used and `orderListId` is ignored.
+
+**Data Source:** Database
+
+**Response:**
+
+```json
+{
+  "id": "b53fd5ff-82c7-4a04-bd64-5f9dc42c2100",
+  "status": 200,
+  "result": {
+    "orderListId": 1274512,
+    "contingencyType": "OCO",
+    "listStatusType": "EXEC_STARTED",
+    "listOrderStatus": "EXECUTING",
+    "listClientOrderId": "08985fedd9ea2cf6b28996",
+    "transactionTime": 1660801713793,
+    "symbol": "BTCUSDT",
+    "orders": [
+      {
+        "symbol": "BTCUSDT",
+        "orderId": 12569138901,
+        "clientOrderId": "BqtFCj5odMoWtSqGk2X9tU"
+      },
+      {
+        "symbol": "BTCUSDT",
+        "orderId": 12569138902,
+        "clientOrderId": "jLnZpj5enfMXTuhKB1d0us"
+      }
+    ]
+  },
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 6000,
+      "count": 4
+    }
+  ]
+}
+```
+
+#### Current open Order lists (USER_DATA)
+
+```json
+{
+  "id": "3a4437e2-41a3-4c19-897c-9cadc5dce8b6",
+  "method": "openOrderLists.status",
+  "params": {
+    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
+    "signature": "1bea8b157dd78c3da30359bddcd999e4049749fe50b828e620e12f64e8b433c9",
+    "timestamp": 1660801713831
+  }
+}
+```
+
+Query execution status of all open order lists.
+
+If you need to continuously monitor order status updates, please consider using
+WebSocket Streams:
+
+- [`userDataStream.start`](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user-data-stream-requests)
+  request
+- [`executionReport`](/docs/binance-spot-api-docs/user-data-stream#order-update)
+  user data stream event
+
+**Weight**: 6
+
+**Parameters:**
+
+| Name           | Type     | Mandatory | Description                                |
+| -------------- | -------- | --------- | ------------------------------------------ |
+| \-`apiKey`     | \-STRING | \-YES     |                                            |
+| \-`recvWindow` | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
+| \-`signature`  | \-STRING | \-YES     |                                            |
+| \-`timestamp`  | \-LONG   | \-YES     |                                            |
+
+**Data Source:** Database
+
+**Response:**
+
+```json
+{
+  "id": "3a4437e2-41a3-4c19-897c-9cadc5dce8b6",
+  "status": 200,
+  "result": [
+    {
+      "orderListId": 0,
+      "contingencyType": "OCO",
+      "listStatusType": "EXEC_STARTED",
+      "listOrderStatus": "EXECUTING",
+      "listClientOrderId": "08985fedd9ea2cf6b28996",
+      "transactionTime": 1660801713793,
+      "symbol": "BTCUSDT",
+      "orders": [
+        {
+          "symbol": "BTCUSDT",
+          "orderId": 4,
+          "clientOrderId": "CUhLgTXnX5n2c0gWiLpV4d"
+        },
+        {
+          "symbol": "BTCUSDT",
+          "orderId": 5,
+          "clientOrderId": "1ZqG7bBuYwaF4SU8CwnwHm"
+        }
+      ]
+    }
+  ],
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 6000,
+      "count": 6
+    }
+  ]
+}
+```
+
+#### Account order list history (USER_DATA)
 
 ```json
 {
@@ -6197,6 +6145,69 @@ Notes:
       "intervalNum": 1,
       "limit": 6000,
       "count": 20
+    }
+  ]
+}
+```
+
+#### Unfilled Order Count (USER_DATA)
+
+```json
+{
+  "id": "d3783d8d-f8d1-4d2c-b8a0-b7596af5a664",
+  "method": "account.rateLimits.orders",
+  "params": {
+    "apiKey": "vmPUZE6mv9SD5VNHk4HlWFsOr6aKE2zvsw0MuIgwCIPy6utIco14y7Ju91duEh8A",
+    "signature": "76289424d6e288f4dc47d167ac824e859dabf78736f4348abbbac848d719eb94",
+    "timestamp": 1660801839500
+  }
+}
+```
+
+Query your current unfilled order count for all intervals.
+
+**Weight:** 40
+
+**Parameters:**
+
+| Name           | Type     | Mandatory | Description                                |
+| -------------- | -------- | --------- | ------------------------------------------ |
+| \-`apiKey`     | \-STRING | \-YES     |                                            |
+| \-`recvWindow` | \-LONG   | \-NO      | \-The value cannot be greater than `60000` |
+| \-`signature`  | \-STRING | \-YES     |                                            |
+| \-`timestamp`  | \-LONG   | \-YES     |                                            |
+
+**Data Source:** Memory
+
+**Response:**
+
+```json
+{
+  "id": "d3783d8d-f8d1-4d2c-b8a0-b7596af5a664",
+  "status": 200,
+  "result": [
+    {
+      "rateLimitType": "ORDERS",
+      "interval": "SECOND",
+      "intervalNum": 10,
+      "limit": 50,
+      "count": 0
+    },
+    {
+      "rateLimitType": "ORDERS",
+      "interval": "DAY",
+      "intervalNum": 1,
+      "limit": 160000,
+      "count": 0
+    }
+  ],
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 6000,
+      "count": 40
     }
   ]
 }
@@ -6459,8 +6470,6 @@ Queries all amendments of a single order.
 
 **Weight**: 4
 
-**Data Source:** Database
-
 **Parameters:**
 
 | Name              | Type     | Mandatory | Description                                 |
@@ -6471,6 +6480,8 @@ Queries all amendments of a single order.
 | \-limit           | \-INT    | \-NO      | \-Default:500; Maximum: 1000                |
 | \-recvWindow      | \-LONG   | \-NO      | \-The value cannot be greater than `60000`. |
 | \-timestamp       | \-LONG   | \-YES     |                                             |
+
+**Data Source:** Database
 
 **Response:**
 

--- a/docs/binance/spot/public_websocket_api.md
+++ b/docs/binance/spot/public_websocket_api.md
@@ -1392,7 +1392,7 @@ To apply an event to your local order book, follow this update procedure:
   disconnected after the 24-hour mark.
 - Responses are in JSON by default. To receive responses in SBE, refer to the
   [SBE FAQ](/docs/binance-spot-api-docs/faqs/sbe_faq) page.
-- The WebSocket server will send a `ping frame` every 20 seconds.\`
+- The WebSocket server will send a `ping frame` every 20 seconds.
   - If the WebSocket server does not receive a `pong frame` back from the
     connection within a minute the connection will be disconnected.
   - When you receive a ping, you must send a pong with a copy of ping's payload
@@ -1403,7 +1403,7 @@ To apply an event to your local order book, follow this update procedure:
 - All timestamps in the JSON responses are in **milliseconds in UTC by
   default**. To receive the information in microseconds, please add the
   parameter `timeUnit=MICROSECOND` or `timeUnit=microsecond` in the URL.
-- Timestamp parameters (e.g. `startTime`, `endTime`, `timestamp)` can be passed
+- Timestamp parameters (e.g. `startTime`, `endTime`, `timestamp`) can be passed
   in milliseconds or microseconds.
 - All field names and values are **case-sensitive**, unless noted otherwise.
 - If there are enums or terms you want clarification on, please see
@@ -1592,7 +1592,7 @@ error codes and messages.
 User Data Stream events for non-SBE sessions are sent as JSON in **text
 frames**, one event per frame.
 
-Events in SBE sessions will be sent as **binary frames.**
+Events in SBE sessions will be sent as **binary frames**.
 
 Please refer to
 [`userDataStream.subscribe`](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user_data_stream_subscribe)


### PR DESCRIPTION
This pull request makes minor corrections to the `docs/binance/spot/public_websocket_api.md` file, focusing on fixing punctuation and formatting issues to improve clarity and consistency.

Documentation improvements:

* Removed an extraneous backtick from the sentence about WebSocket server ping frames. (`[docs/binance/spot/public_websocket_api.mdL1395-R1395](diffhunk://#diff-8fd629f7ad6fb890df0d0ec59a8d07dce509f1d7b5f8862c52b4a9b6d63be5e1L1395-R1395)`)
* Corrected the placement of a closing parenthesis in the description of timestamp parameters. (`[docs/binance/spot/public_websocket_api.mdL1406-R1406](diffhunk://#diff-8fd629f7ad6fb890df0d0ec59a8d07dce509f1d7b5f8862c52b4a9b6d63be5e1L1406-R1406)`)
* Removed an unnecessary period from the description of SBE session event frames. (`[docs/binance/spot/public_websocket_api.mdL1595-R1595](diffhunk://#diff-8fd629f7ad6fb890df0d0ec59a8d07dce509f1d7b5f8862c52b4a9b6d63be5e1L1595-R1595)`)