### PR TITLE
Binance Spot API Documentation Update

### DIFF
--- a/docs/binance/spot/change_log.md
+++ b/docs/binance/spot/change_log.md
@@ -2,7 +2,17 @@
 
 ## CHANGELOG for Binance's API
 
-**Last Updated: 2025-05-22**
+**Last Updated: 2025-05-28**
+
+#### 2025-05-28
+
+- Documented API timeout value and error under General API Information for each
+  API:
+  - [FIX](/docs/binance-spot-api-docs/fix-api#general-api-information)
+  - [REST](/docs/rest-api.md#general-api-information)
+  - [WebSocket](/docs/web-socket-api.md#general-api-information)
+
+---
 
 #### 2025-05-22
 

--- a/docs/binance/spot/fix_api.md
+++ b/docs/binance/spot/fix_api.md
@@ -4,11 +4,20 @@
 
 > \[!NOTE\] This API can only be used with the SPOT Exchange.
 
-### General Information
+### General API Information
 
-FIX connections require TLS encryption. Please either use native TCP+TLS
-connection or set up a local proxy such as [stunnel](https://www.stunnel.org/)
-to handle TLS encryption.
+- FIX connections require TLS encryption. Please either use native TCP+TLS
+  connection or set up a local proxy such as [stunnel](https://www.stunnel.org/)
+  to handle TLS encryption.
+- APIs have a timeout of 10 seconds when processing a request. If a response
+  from the Matching Engine takes longer than this, the API responds with
+  "Timeout waiting for response from backend server. Send status unknown;
+  execution status unknown."
+  [(-1007 TIMEOUT)](/docs/binance-spot-api-docs/errors#-1007-timeout)
+  - This does not always mean that the request failed in the Matching Engine.
+  - If the status of the request has not appeared in
+    [User Data Stream](/docs/binance-spot-api-docs/user-data-stream), please
+    perform an API query for its status.
 
 **FIX sessions only support Ed25519 keys.**
 

--- a/docs/binance/spot/private_rest_api.md
+++ b/docs/binance/spot/private_rest_api.md
@@ -745,6 +745,15 @@ following messages which will indicate the specific error:
 - If there are enums or terms you want clarification on, please see the
   [SPOT Glossary](/docs/binance-spot-api-docs/faqs/spot_glossary) for more
   information.
+- APIs have a timeout of 10 seconds when processing a request. If a response
+  from the Matching Engine takes longer than this, the API responds with
+  "Timeout waiting for response from backend server. Send status unknown;
+  execution status unknown."
+  [(-1007 TIMEOUT)](/docs/binance-spot-api-docs/errors#-1007-timeout)
+  - This does not always mean that the request failed in the Matching Engine.
+  - If the status of the request has not appeared in
+    [User Data Stream](/docs/binance-spot-api-docs/user-data-stream), please
+    perform an API query for its status.
 
 > Source:
 > [https://developers.binance.com/docs/binance-spot-api-docs/rest-api/general-api-information](https://developers.binance.com/docs/binance-spot-api-docs/rest-api/general-api-information)

--- a/docs/binance/spot/private_websocket_api.md
+++ b/docs/binance/spot/private_websocket_api.md
@@ -1675,6 +1675,15 @@ To apply an event to your local order book, follow this update procedure:
 - If there are enums or terms you want clarification on, please see
   [SPOT Glossary](/docs/binance-spot-api-docs/faqs/spot_glossary) for more
   information.
+- APIs have a timeout of 10 seconds when processing a request. If a response
+  from the Matching Engine takes longer than this, the API responds with
+  "Timeout waiting for response from backend server. Send status unknown;
+  execution status unknown."
+  [(-1007 TIMEOUT)](/docs/binance-spot-api-docs/errors#-1007-timeout)
+  - This does not always mean that the request failed in the Matching Engine.
+  - If the status of the request has not appeared in
+    [User Data Stream](/docs/binance-spot-api-docs/user-data-stream), please
+    perform an API query for its status.
 
 > Source:
 > [https://developers.binance.com/docs/binance-spot-api-docs/websocket-api/general-api-information](https://developers.binance.com/docs/binance-spot-api-docs/websocket-api/general-api-information)

--- a/docs/binance/spot/public_rest_api.md
+++ b/docs/binance/spot/public_rest_api.md
@@ -745,6 +745,15 @@ following messages which will indicate the specific error:
 - If there are enums or terms you want clarification on, please see the
   [SPOT Glossary](/docs/binance-spot-api-docs/faqs/spot_glossary) for more
   information.
+- APIs have a timeout of 10 seconds when processing a request. If a response
+  from the Matching Engine takes longer than this, the API responds with
+  "Timeout waiting for response from backend server. Send status unknown;
+  execution status unknown."
+  [(-1007 TIMEOUT)](/docs/binance-spot-api-docs/errors#-1007-timeout)
+  - This does not always mean that the request failed in the Matching Engine.
+  - If the status of the request has not appeared in
+    [User Data Stream](/docs/binance-spot-api-docs/user-data-stream), please
+    perform an API query for its status.
 
 > Source:
 > [https://developers.binance.com/docs/binance-spot-api-docs/rest-api/general-api-information](https://developers.binance.com/docs/binance-spot-api-docs/rest-api/general-api-information)

--- a/docs/binance/spot/public_websocket_api.md
+++ b/docs/binance/spot/public_websocket_api.md
@@ -1409,6 +1409,15 @@ To apply an event to your local order book, follow this update procedure:
 - If there are enums or terms you want clarification on, please see
   [SPOT Glossary](/docs/binance-spot-api-docs/faqs/spot_glossary) for more
   information.
+- APIs have a timeout of 10 seconds when processing a request. If a response
+  from the Matching Engine takes longer than this, the API responds with
+  "Timeout waiting for response from backend server. Send status unknown;
+  execution status unknown."
+  [(-1007 TIMEOUT)](/docs/binance-spot-api-docs/errors#-1007-timeout)
+  - This does not always mean that the request failed in the Matching Engine.
+  - If the status of the request has not appeared in
+    [User Data Stream](/docs/binance-spot-api-docs/user-data-stream), please
+    perform an API query for its status.
 
 > Source:
 > [https://developers.binance.com/docs/binance-spot-api-docs/websocket-api/general-api-information](https://developers.binance.com/docs/binance-spot-api-docs/websocket-api/general-api-information)


### PR DESCRIPTION
This pull request updates Binance API documentation to include information about API timeout behavior and the associated error code across multiple API types. The changes standardize the documentation to clarify how timeouts are handled and guide users on how to verify the status of their requests.

### Documentation Updates for API Timeout Behavior:

* **General API Information Section Updates:**
  - Updated the `docs/binance/spot/fix_api.md` file to specify that APIs have a 10-second timeout and describe the error message and code (`-1007 TIMEOUT`) returned when a timeout occurs. Additional guidance is provided for verifying the status of requests.

* **REST API Documentation Updates:**
  - Added details about the 10-second timeout and the `-1007 TIMEOUT` error to the `docs/binance/spot/private_rest_api.md` and `docs/binance/spot/public_rest_api.md` files. These updates include explanations about the error message and steps to check the status of requests. [[1]](diffhunk://#diff-0fd860f4c27103a1db4f0a313d2e261bcc9a615ec0c015a59f6d85b040af8a9aR748-R756) [[2]](diffhunk://#diff-6c1da7cf7fcdf643708e730152bb54f2e4f17641624bf4fc7b8cdc4eb0a24551R748-R756)

* **WebSocket API Documentation Updates:**
  - Updated the `docs/binance/spot/private_websocket_api.md` and `docs/binance/spot/public_websocket_api.md` files to include the same timeout information and error handling guidance as the REST API documentation. [[1]](diffhunk://#diff-a77f386cedbd3d817db1f18b205b2852ecf523d58d8ccdb251f5e32e4bec0733R1678-R1686) [[2]](diffhunk://#diff-8fd629f7ad6fb890df0d0ec59a8d07dce509f1d7b5f8862c52b4a9b6d63be5e1R1412-R1420)

* **Changelog Update:**
  - Updated the `docs/binance/spot/change_log.md` file to reflect the addition of timeout documentation for FIX, REST, and WebSocket APIs in the changelog for 2025-05-28.