### PR TITLE
Coinbase Exchange API Documentation Update

### DIFF
--- a/docs/coinbase/exchange/private_rest_api.md
+++ b/docs/coinbase/exchange/private_rest_api.md
@@ -863,7 +863,6 @@ This endpoint requires the "trade" permission.
 | time_in_force | [optional] `GTC`, `GTT`, `IOC`, or `FOK` (default is `GTC`)                                                                     |
 | cancel_after  | [optional]\*\* `min`, `hour`, `day`                                                                                             |
 | post_only     | [optional]\*\*\* Post only flag                                                                                                 |
-| max_floor     | [optional] Max size of iceberg order to display. Must be &gt; 10% of OrderQty.                                                  |
 
 \* One of size or funds is required. Only one may be specified  
 \*\* Requires `time_in_force` to be `GTT`  
@@ -1116,37 +1115,35 @@ canceled.
 
 ### Response: 200 The new order that was successfully created
 
-| Property           | Type      | Description                                                             |
-| ------------------ | --------- | ----------------------------------------------------------------------- |
-| id                 | string    | uuid                                                                    |
-| price              | string    | price per unit of base currency                                         |
-| size               | string    | amount of base currency to buy/sell                                     |
-| product_id         | string    | book the order was placed on                                            |
-| profile_id         | string    | profile_id that placed the order                                        |
-| side               | string    | Possible values: [buy, sell]                                            |
-| funds              | string    | amount of quote currency to spend (for market orders)                   |
-| specified_funds    | string    | funds with fees                                                         |
-| type               | string    | Possible values: [limit, market, stop]                                  |
-| time_in_force      | string    | Possible values: [GTC, GTT, IOC, FOK]                                   |
-| expire_time        | date-time | timestamp at which order expires                                        |
-| post_only          | boolean   | if true, forces order to be `maker` only                                |
-| created_at         | date-time | timestamp at which order was placed                                     |
-| done_at            | date-time | timestamp at which order was done                                       |
-| done_reason        | string    | reason order was done (filled, rejected, or otherwise)                  |
-| reject_reason      | string    | reason order was rejected by engine                                     |
-| fill_fees          | string    | fees paid on current filled amount                                      |
-| filled_size        | string    | amount (in base currency) of the order that has been filled             |
-| executed_value     | string    |                                                                         |
-| status             | string    | Possible values: [open, pending, rejected, done, active, received, all] |
-| settled            | boolean   | true if funds have been exchanged and settled                           |
-| stop               | string    | Possible values: [loss, entry]                                          |
-| stop_price         | string    | price (in quote currency) at which to execute the order                 |
-| funding_amount     | string    |                                                                         |
-| client_oid         | string    | client order id                                                         |
-| market_type        | string    | market type where order was traded                                      |
-| max_floor          | string    | maximum visible quantity for iceberg order                              |
-| secondary_order_id | string    | order id for the visible order for iceberg order                        |
-| stop_limit_price   | string    | stop limit price for TPSL order                                         |
+| Property         | Type      | Description                                                             |
+| ---------------- | --------- | ----------------------------------------------------------------------- |
+| id               | string    | uuid                                                                    |
+| price            | string    | price per unit of base currency                                         |
+| size             | string    | amount of base currency to buy/sell                                     |
+| product_id       | string    | book the order was placed on                                            |
+| profile_id       | string    | profile_id that placed the order                                        |
+| side             | string    | Possible values: [buy, sell]                                            |
+| funds            | string    | amount of quote currency to spend (for market orders)                   |
+| specified_funds  | string    | funds with fees                                                         |
+| type             | string    | Possible values: [limit, market, stop]                                  |
+| time_in_force    | string    | Possible values: [GTC, GTT, IOC, FOK]                                   |
+| expire_time      | date-time | timestamp at which order expires                                        |
+| post_only        | boolean   | if true, forces order to be `maker` only                                |
+| created_at       | date-time | timestamp at which order was placed                                     |
+| done_at          | date-time | timestamp at which order was done                                       |
+| done_reason      | string    | reason order was done (filled, rejected, or otherwise)                  |
+| reject_reason    | string    | reason order was rejected by engine                                     |
+| fill_fees        | string    | fees paid on current filled amount                                      |
+| filled_size      | string    | amount (in base currency) of the order that has been filled             |
+| executed_value   | string    |                                                                         |
+| status           | string    | Possible values: [open, pending, rejected, done, active, received, all] |
+| settled          | boolean   | true if funds have been exchanged and settled                           |
+| stop             | string    | Possible values: [loss, entry]                                          |
+| stop_price       | string    | price (in quote currency) at which to execute the order                 |
+| funding_amount   | string    |                                                                         |
+| client_oid       | string    | client order id                                                         |
+| market_type      | string    | market type where order was traded                                      |
+| stop_limit_price | string    | stop limit price for TPSL order                                         |
 
 ### Response: 401 Unauthorized.
 
@@ -1336,37 +1333,35 @@ more information.
 
 ### Response: 200
 
-| Property           | Type      | Description                                                             |
-| ------------------ | --------- | ----------------------------------------------------------------------- |
-| id                 | string    | uuid                                                                    |
-| price              | string    | price per unit of base currency                                         |
-| size               | string    | amount of base currency to buy/sell                                     |
-| product_id         | string    | book the order was placed on                                            |
-| profile_id         | string    | profile_id that placed the order                                        |
-| side               | string    | Possible values: [buy, sell]                                            |
-| funds              | string    | amount of quote currency to spend (for market orders)                   |
-| specified_funds    | string    | funds with fees                                                         |
-| type               | string    | Possible values: [limit, market, stop]                                  |
-| time_in_force      | string    | Possible values: [GTC, GTT, IOC, FOK]                                   |
-| expire_time        | date-time | timestamp at which order expires                                        |
-| post_only          | boolean   | if true, forces order to be `maker` only                                |
-| created_at         | date-time | timestamp at which order was placed                                     |
-| done_at            | date-time | timestamp at which order was done                                       |
-| done_reason        | string    | reason order was done (filled, rejected, or otherwise)                  |
-| reject_reason      | string    | reason order was rejected by engine                                     |
-| fill_fees          | string    | fees paid on current filled amount                                      |
-| filled_size        | string    | amount (in base currency) of the order that has been filled             |
-| executed_value     | string    |                                                                         |
-| status             | string    | Possible values: [open, pending, rejected, done, active, received, all] |
-| settled            | boolean   | true if funds have been exchanged and settled                           |
-| stop               | string    | Possible values: [loss, entry]                                          |
-| stop_price         | string    | price (in quote currency) at which to execute the order                 |
-| funding_amount     | string    |                                                                         |
-| client_oid         | string    | client order id                                                         |
-| market_type        | string    | market type where order was traded                                      |
-| max_floor          | string    | maximum visible quantity for iceberg order                              |
-| secondary_order_id | string    | order id for the visible order for iceberg order                        |
-| stop_limit_price   | string    | stop limit price for TPSL order                                         |
+| Property         | Type      | Description                                                             |
+| ---------------- | --------- | ----------------------------------------------------------------------- |
+| id               | string    | uuid                                                                    |
+| price            | string    | price per unit of base currency                                         |
+| size             | string    | amount of base currency to buy/sell                                     |
+| product_id       | string    | book the order was placed on                                            |
+| profile_id       | string    | profile_id that placed the order                                        |
+| side             | string    | Possible values: [buy, sell]                                            |
+| funds            | string    | amount of quote currency to spend (for market orders)                   |
+| specified_funds  | string    | funds with fees                                                         |
+| type             | string    | Possible values: [limit, market, stop]                                  |
+| time_in_force    | string    | Possible values: [GTC, GTT, IOC, FOK]                                   |
+| expire_time      | date-time | timestamp at which order expires                                        |
+| post_only        | boolean   | if true, forces order to be `maker` only                                |
+| created_at       | date-time | timestamp at which order was placed                                     |
+| done_at          | date-time | timestamp at which order was done                                       |
+| done_reason      | string    | reason order was done (filled, rejected, or otherwise)                  |
+| reject_reason    | string    | reason order was rejected by engine                                     |
+| fill_fees        | string    | fees paid on current filled amount                                      |
+| filled_size      | string    | amount (in base currency) of the order that has been filled             |
+| executed_value   | string    |                                                                         |
+| status           | string    | Possible values: [open, pending, rejected, done, active, received, all] |
+| settled          | boolean   | true if funds have been exchanged and settled                           |
+| stop             | string    | Possible values: [loss, entry]                                          |
+| stop_price       | string    | price (in quote currency) at which to execute the order                 |
+| funding_amount   | string    |                                                                         |
+| client_oid       | string    | client order id                                                         |
+| market_type      | string    | market type where order was traded                                      |
+| stop_limit_price | string    | stop limit price for TPSL order                                         |
 
 ### Response: 401 Unauthorized.
 
@@ -1474,37 +1469,35 @@ market conditions.
 
 ### Response: 200
 
-| Property           | Type      | Description                                                             |
-| ------------------ | --------- | ----------------------------------------------------------------------- |
-| id                 | string    | uuid                                                                    |
-| price              | string    | price per unit of base currency                                         |
-| size               | string    | amount of base currency to buy/sell                                     |
-| product_id         | string    | book the order was placed on                                            |
-| profile_id         | string    | profile_id that placed the order                                        |
-| side               | string    | Possible values: [buy, sell]                                            |
-| funds              | string    | amount of quote currency to spend (for market orders)                   |
-| specified_funds    | string    | funds with fees                                                         |
-| type               | string    | Possible values: [limit, market, stop]                                  |
-| time_in_force      | string    | Possible values: [GTC, GTT, IOC, FOK]                                   |
-| expire_time        | date-time | timestamp at which order expires                                        |
-| post_only          | boolean   | if true, forces order to be `maker` only                                |
-| created_at         | date-time | timestamp at which order was placed                                     |
-| done_at            | date-time | timestamp at which order was done                                       |
-| done_reason        | string    | reason order was done (filled, rejected, or otherwise)                  |
-| reject_reason      | string    | reason order was rejected by engine                                     |
-| fill_fees          | string    | fees paid on current filled amount                                      |
-| filled_size        | string    | amount (in base currency) of the order that has been filled             |
-| executed_value     | string    |                                                                         |
-| status             | string    | Possible values: [open, pending, rejected, done, active, received, all] |
-| settled            | boolean   | true if funds have been exchanged and settled                           |
-| stop               | string    | Possible values: [loss, entry]                                          |
-| stop_price         | string    | price (in quote currency) at which to execute the order                 |
-| funding_amount     | string    |                                                                         |
-| client_oid         | string    | client order id                                                         |
-| market_type        | string    | market type where order was traded                                      |
-| max_floor          | string    | maximum visible quantity for iceberg order                              |
-| secondary_order_id | string    | order id for the visible order for iceberg order                        |
-| stop_limit_price   | string    | stop limit price for TPSL order                                         |
+| Property         | Type      | Description                                                             |
+| ---------------- | --------- | ----------------------------------------------------------------------- |
+| id               | string    | uuid                                                                    |
+| price            | string    | price per unit of base currency                                         |
+| size             | string    | amount of base currency to buy/sell                                     |
+| product_id       | string    | book the order was placed on                                            |
+| profile_id       | string    | profile_id that placed the order                                        |
+| side             | string    | Possible values: [buy, sell]                                            |
+| funds            | string    | amount of quote currency to spend (for market orders)                   |
+| specified_funds  | string    | funds with fees                                                         |
+| type             | string    | Possible values: [limit, market, stop]                                  |
+| time_in_force    | string    | Possible values: [GTC, GTT, IOC, FOK]                                   |
+| expire_time      | date-time | timestamp at which order expires                                        |
+| post_only        | boolean   | if true, forces order to be `maker` only                                |
+| created_at       | date-time | timestamp at which order was placed                                     |
+| done_at          | date-time | timestamp at which order was done                                       |
+| done_reason      | string    | reason order was done (filled, rejected, or otherwise)                  |
+| reject_reason    | string    | reason order was rejected by engine                                     |
+| fill_fees        | string    | fees paid on current filled amount                                      |
+| filled_size      | string    | amount (in base currency) of the order that has been filled             |
+| executed_value   | string    |                                                                         |
+| status           | string    | Possible values: [open, pending, rejected, done, active, received, all] |
+| settled          | boolean   | true if funds have been exchanged and settled                           |
+| stop             | string    | Possible values: [loss, entry]                                          |
+| stop_price       | string    | price (in quote currency) at which to execute the order                 |
+| funding_amount   | string    |                                                                         |
+| client_oid       | string    | client order id                                                         |
+| market_type      | string    | market type where order was traded                                      |
+| stop_limit_price | string    | stop limit price for TPSL order                                         |
 
 ### Response: 401 Unauthorized.
 


### PR DESCRIPTION
This pull request updates the Coinbase Exchange Private REST API documentation. The changes primarily focus on removing references to iceberg orders and improving table formatting for consistency.

### Removal of iceberg order-related fields:
* Removed the `max_floor` and `secondary_order_id` fields from the request and response sections, as they are no longer relevant to the API. [[1]](diffhunk://#diff-856d41efa159f8be90fd0deeda1220f390edf6b96da5dc782ce30003678ba743L866) [[2]](diffhunk://#diff-856d41efa159f8be90fd0deeda1220f390edf6b96da5dc782ce30003678ba743L1147-L1148) [[3]](diffhunk://#diff-856d41efa159f8be90fd0deeda1220f390edf6b96da5dc782ce30003678ba743L1367-L1368) [[4]](diffhunk://#diff-856d41efa159f8be90fd0deeda1220f390edf6b96da5dc782ce30003678ba743L1505-L1506)

### Table formatting improvements:
* Standardized the column alignment in several response property tables by fixing inconsistent dashes in the header row. [[1]](diffhunk://#diff-856d41efa159f8be90fd0deeda1220f390edf6b96da5dc782ce30003678ba743L1120-R1119) [[2]](diffhunk://#diff-856d41efa159f8be90fd0deeda1220f390edf6b96da5dc782ce30003678ba743L1340-R1337) [[3]](diffhunk://#diff-856d41efa159f8be90fd0deeda1220f390edf6b96da5dc782ce30003678ba743L1478-R1473)