### PR TITLE
Binance Options API Documentation Update

### DIFF
--- a/docs/binance/usdm/private_rest_api.md
+++ b/docs/binance/usdm/private_rest_api.md
@@ -3498,17 +3498,17 @@ GET `/fapi/v3/balance`
 
 ```json
 [
- {
-   "accountAlias": "SgsR",              // unique account code
-   "asset": "USDT",  	                // asset name
-   "balance": "122607.35137903",        // wallet balance
-   "crossWalletBalance": "23.72469206", // crossed wallet balance
-   "crossUnPnl": "0.00000000"           // unrealized profit of crossed positions
-   "availableBalance": "23.72469206",   // available balance
-   "maxWithdrawAmount": "23.72469206",  // maximum amount for transfer out
-   "marginAvailable": true,             // whether the asset can be used as margin in Multi-Assets mode
-   "updateTime": 1617939110373
- }
+  {
+    "accountAlias": "SgsR", // unique account code
+    "asset": "USDT", // asset name
+    "balance": "122607.35137903", // wallet balance
+    "crossWalletBalance": "23.72469206", // crossed wallet balance
+    "crossUnPnl": "0.00000000", // unrealized profit of crossed positions
+    "availableBalance": "23.72469206", // available balance
+    "maxWithdrawAmount": "23.72469206", // maximum amount for transfer out
+    "marginAvailable": true, // whether the asset can be used as margin in Multi-Assets mode
+    "updateTime": 1617939110373
+  }
 ]
 ```
 
@@ -3540,17 +3540,17 @@ GET `/fapi/v2/balance`
 
 ```json
 [
- 	{
- 		"accountAlias": "SgsR",    // unique account code
- 		"asset": "USDT",  	// asset name
- 		"balance": "122607.35137903", // wallet balance
- 		"crossWalletBalance": "23.72469206", // crossed wallet balance
-  		"crossUnPnl": "0.00000000"  // unrealized profit of crossed positions
-  		"availableBalance": "23.72469206",       // available balance
-  		"maxWithdrawAmount": "23.72469206",     // maximum amount for transfer out
-  		"marginAvailable": true,    // whether the asset can be used as margin in Multi-Assets mode
-  		"updateTime": 1617939110373
-	}
+  {
+    "accountAlias": "SgsR", // unique account code
+    "asset": "USDT", // asset name
+    "balance": "122607.35137903", // wallet balance
+    "crossWalletBalance": "23.72469206", // crossed wallet balance
+    "crossUnPnl": "0.00000000", // unrealized profit of crossed positions
+    "availableBalance": "23.72469206", // available balance
+    "maxWithdrawAmount": "23.72469206", // maximum amount for transfer out
+    "marginAvailable": true, // whether the asset can be used as margin in Multi-Assets mode
+    "updateTime": 1617939110373
+  }
 ]
 ```
 


### PR DESCRIPTION
This pull request includes minor formatting adjustments to JSON response examples in the Binance USDM Private REST API documentation. The changes ensure consistent spacing and alignment for comments in the JSON objects.

Formatting adjustments in API documentation:

* [`docs/binance/usdm/private_rest_api.md`](diffhunk://#diff-6a429050c9ed79c428442ad791bf05526d1f71ba2b2ea114d7ebe877dbadc5b7L3506-R3506): Updated the `crossUnPnl` comment in the `GET /fapi/v3/balance` endpoint example to align with the formatting of other comments.
* [`docs/binance/usdm/private_rest_api.md`](diffhunk://#diff-6a429050c9ed79c428442ad791bf05526d1f71ba2b2ea114d7ebe877dbadc5b7L3548-R3548): Corrected the spacing of the `crossUnPnl` comment in the `GET /fapi/v2/balance` endpoint example for consistent formatting.