### PR TITLE
Binance Spot API Documentation Update

### DIFF
--- a/docs/binance/spot/change_log.md
+++ b/docs/binance/spot/change_log.md
@@ -2,7 +2,19 @@
 
 ## CHANGELOG for Binance's API
 
-**Last Updated: 2025-05-28**
+**Last Updated: 2025-06-04**
+
+#### 2025-06-04
+
+REST and WebSocket API:
+
+- Reminder that SBE 2:0 schema will be retired on 2025-06-12,
+  [6 months after being deprecated](/docs/binance-spot-api-docs/faqs/sbe_faq#sbe-schema).
+- The
+  [SBE lifecycle for Production](https://github.com/binance/binance-spot-api-docs/blob/master/sbe/schemas/sbe_schema_lifecycle_prod.json)
+  has been updated to reflect this change.
+
+---
 
 #### 2025-05-28
 


### PR DESCRIPTION
This pull request updates the changelog for Binance's API documentation to reflect upcoming changes to the SBE schema lifecycle.

Changes to the changelog:

* [`docs/binance/spot/change_log.md`](diffhunk://#diff-af5680cbde1fbca404443e5347bb0e99dc8838f31db22eef370f478593a6675eL5-R17): Updated the "Last Updated" date to 2025-06-04 and added a note about the retirement of the SBE 2:0 schema on 2025-06-12, along with links to the SBE lifecycle documentation for production.