### PR TITLE
Crypto.com API Documentation Update

### DIFF
--- a/docs/cryptocom/private_rest_api.md
+++ b/docs/cryptocom/private_rest_api.md
@@ -53,6 +53,11 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-05-29
+
+  - transaction_time_ns field was added into `user.order.{instrument_name}`
+    response
+
 - 2025-03-14
 
   - Removed deprecated attributes system_label in `private/get-accounts`

--- a/docs/cryptocom/public_rest_api.md
+++ b/docs/cryptocom/public_rest_api.md
@@ -53,6 +53,11 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-05-29
+
+  - transaction_time_ns field was added into `user.order.{instrument_name}`
+    response
+
 - 2025-03-14
 
   - Removed deprecated attributes system_label in `private/get-accounts`
@@ -1251,7 +1256,7 @@ GET
           "c": "0.03955106",      // 24-hour price change, null if there weren't any trades
           "b": "51170.000000",    // The current best bid price, null if there aren't any bids
           "k": "51180.000000",    // The current best ask price, null if there aren't any asks
-          "t": 1613580710768
+          "t": 1613580710768      // The published timestamp in ms
         }]
       }
     }
@@ -1286,7 +1291,7 @@ GET
 | c    | string | 24-hour price change, null if there weren't any trades          |
 | b    | string | The current best bid price, null if there aren't any bids       |
 | k    | string | The current best ask price, null if there aren't any asks       |
-| t    | number | Trade timestamp                                                 |
+| t    | number | The published timestamp in ms                                   |
 
 ## public/get-valuations
 

--- a/docs/cryptocom/websocket_api.md
+++ b/docs/cryptocom/websocket_api.md
@@ -53,6 +53,11 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-05-29
+
+  - transaction_time_ns field was added into `user.order.{instrument_name}`
+    response
+
 - 2025-03-14
 
   - Removed deprecated attributes system_label in `private/get-accounts`
@@ -977,6 +982,7 @@ Websocket (User API) Websocket (Market Data Subscriptions)
           "create_time": 1613575617173,
           "create_time_ns": "1613575617173123456",
           "update_time": 1613575617173
+          "transaction_time_ns": "1613570791060827635",
         }]
       }
     }
@@ -1036,8 +1042,10 @@ string | Cumulative executed fee | | status | string | Order status:
 \- `EXPIRED` | | update_user_id | string | Updated user | | order_date | string
 | Order creation date | | create_time | number | Order creation timestamp | |
 create_time_ns | string | Order creation timestamp (nanosecond) | | update_time
-| number | Order update timestamp | | instrument_name | string | e.g.
-BTCUSD-PERP | | fee_instrument_name | string | Currency used for the fees |
+| number | Order update timestamp | | transaction_time_ns | string | Order
+transaction timestamp (nanosecond). This field is equivalent to
+TransactTime(Tag 60) in FIX | | instrument_name | string | e.g. BTCUSD-PERP | |
+fee_instrument_name | string | Currency used for the fees |
 
 Note: To detect a 'partial filled' status, look for `status` as `ACTIVE` and
 `cumulative_quantity` > 0.


### PR DESCRIPTION
**PR Summary: Cryptocurrency Exchange API Documentation Updates**

- **Added `transaction_time_ns` Field**
  - Introduced the `transaction_time_ns` field to the `user.order.{instrument_name}` response across the following documentation sections:
    - Private REST API
    - Public REST API
    - WebSocket API
  - For WebSocket API, clarified that `transaction_time_ns` represents the order transaction timestamp in nanoseconds, equivalent to TransactTime (Tag 60) in FIX.

- **Documentation Improvements**
  - Updated the description for the `t` field in the `public/get-ticker` endpoint response:
    - Changed from "Trade timestamp" to "The published timestamp in ms" for improved clarity in both the example and parameter table.

No new endpoints were added; changes focus on response field additions and documentation clarity.