### PR TITLE
OKX API Documentation Update

### DIFF
--- a/docs/okx/private_order_book_trading_websocket_api.md
+++ b/docs/okx/private_order_book_trading_websocket_api.md
@@ -231,7 +231,7 @@ Client will receive the information in the following scenarios:
 
 - Websocket disconnect for service upgrade
 
-30 seconds prior to the upgrade of the WebSocket service, the notification
+60 seconds prior to the upgrade of the WebSocket service, the notification
 message will be sent to users indicating that the connection will soon be
 disconnected. Users are encouraged to establish a new connection to prevent any
 disruptions caused by disconnection.

--- a/docs/okx/public_market_data_websocket_api.md
+++ b/docs/okx/public_market_data_websocket_api.md
@@ -231,7 +231,7 @@ Client will receive the information in the following scenarios:
 
 - Websocket disconnect for service upgrade
 
-30 seconds prior to the upgrade of the WebSocket service, the notification
+60 seconds prior to the upgrade of the WebSocket service, the notification
 message will be sent to users indicating that the connection will soon be
 disconnected. Users are encouraged to establish a new connection to prevent any
 disruptions caused by disconnection.


### PR DESCRIPTION
**PR Summary:**

- Updated the following API documentation sections:
  - Private Order Book Trading WebSocket API
  - Public Market Data WebSocket API
- Changed the advance notification period for WebSocket service upgrades from 30 seconds to 60 seconds.
- Improved clarity regarding the timing of service upgrade notifications to users.