### PR TITLE
Binance Spot API Documentation Update

### DIFF
--- a/docs/binance/spot/change_log.md
+++ b/docs/binance/spot/change_log.md
@@ -21,8 +21,8 @@ REST and WebSocket API:
 - Documented API timeout value and error under General API Information for each
   API:
   - [FIX](/docs/binance-spot-api-docs/fix-api#general-api-information)
-  - [REST](/docs/rest-api.md#general-api-information)
-  - [WebSocket](/docs/web-socket-api.md#general-api-information)
+  - [REST](/docs/binance-spot-api-docs/rest-api/general-api-information)
+  - [WebSocket](/docs/binance-spot-api-docs/websocket-api/general-api-information)
 
 ---
 
@@ -50,8 +50,8 @@ REST and WebSocket API:
       and Unfilled Order Count (order placement endpoints of all APIs).
   - The documentation for Timing security has been updated to reflect the
     additional check.
-    - [REST API](/docs/rest-api.md#timing-security)
-    - [WebSocket API](/docs/web-socket-api.md#timing-security)
+    - [REST API](/docs/binance-spot-api-docs/rest-api/endpoint-security-type#timing-security)
+    - [WebSocket API](/docs/binance-spot-api-docs/websocket-api/request-security#timing-security)
     - [FIX API](/docs/binance-spot-api-docs/fix-api#timing-security)
 - Fixed a bug in FIX Market Data message InstrumentList `<y>`. Previously, the
   value of `NoRelatedSym(146)` could have been incorrect.
@@ -175,7 +175,7 @@ take a week to complete.
   `listenKey` is now deprecated.**
   - This feature will be removed from our systems at a later date.
 - **Instead, you should get user data updates by subscribing to the
-  [User Data Stream on the WebSocket API](/docs/web-socket-api.md)**.
+  [User Data Stream on the WebSocket API](/docs/websocket-api)**.
   - This should offer slightly better performance **(lower latency)**.
   - This requires the use of an Ed25519 API Key.
 - In a future update, information about the base WebSocket endpoint for the User
@@ -588,8 +588,10 @@ REST and WebSocket API:
 #### 2024-10-17
 
 Changes to Exchange Information (i.e.
-[`GET /api/v3/exchangeInfo`](/docs/rest-api.md#exchangeInfo) from REST and
-[`exchangeInfo`](/docs/web-socket-api.md#exchangeInfo) for WebSocket API).
+[`GET /api/v3/exchangeInfo`](/docs/binance-spot-api-docs/rest-api/general-endpoints#exchangeInfo)
+from REST and
+[`exchangeInfo`](/docs/binance-spot-api-docs/websocket-api/general-requests#exchangeInfo)
+for WebSocket API).
 
 - A new optional parameter `showPermissionSets` can be used to hide the
   permissions from `permissionsSets`; This can be used for a reduced payload

--- a/docs/binance/spot/fix_api.md
+++ b/docs/binance/spot/fix_api.md
@@ -1181,7 +1181,7 @@ Sent by the server in a response to the
 [InstrumentListRequest`<x>`](/docs/binance-spot-api-docs/fix-api#instrumentlistrequest).
 
 > \[!NOTE\] More detailed symbol information is available through the
-> [exchangeInfo](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#exchange-information)
+> [exchangeInfo](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api/general-endpoints.md#exchange-information)
 > endpoint.
 
 | Tag       | Name                    | Type         | Required | Description                                  |

--- a/docs/binance/spot/private_websocket_api.md
+++ b/docs/binance/spot/private_websocket_api.md
@@ -6,12 +6,12 @@
 
 - There are currently two ways to subscribe to the User Data Stream:
   - **\[Preferred\]** Subscribing directly through the
-    [WebSocket API](/docs/binance-spot-api-docs/web-socket-api.md#user_data_stream_subscribe)
+    [WebSocket API](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user_data_stream_subscribe)
     using an API Key.
   - **\[Deprecated\]** Generating a **listen key** using
-    [the REST API](/docs/binance-spot-api-docs/rest-api.md#user-data-stream-requests)
+    [the REST API](/docs/binance-spot-api-docs/rest-api/account-endpoints#user-data-stream-requests)
     or
-    [the WebSocket API](/docs/binance-spot-api-docs/web-socket-api.md#user-data-stream-requests)
+    [the WebSocket API](/docs/binance-spot-api-docs/websocket-api/user-data-stream-requests#user-data-stream-requests)
     and using it to listen on **stream.binance.com**
 - Both sources will push all events related to your account **in real-time**.
 - How to use a listen key on **stream.binance.com**:


### PR DESCRIPTION
This pull request updates documentation links across multiple files to point to the new structured URLs in the Binance Spot API documentation. The changes ensure consistency and direct users to the correct sections of the updated documentation.

### Updates to documentation links:

* **General API Information and Timing Security:**
  - Updated links for REST and WebSocket APIs to reflect the new URL structure for "General API Information" and "Timing Security" sections. (`docs/binance/spot/change_log.md`) [[1]](diffhunk://#diff-af5680cbde1fbca404443e5347bb0e99dc8838f31db22eef370f478593a6675eL24-R25) [[2]](diffhunk://#diff-af5680cbde1fbca404443e5347bb0e99dc8838f31db22eef370f478593a6675eL53-R54)

* **User Data Stream:**
  - Adjusted links for the User Data Stream on the WebSocket API and REST API to point to the updated paths. (`docs/binance/spot/change_log.md`, `docs/binance/spot/private_websocket_api.md`) [[1]](diffhunk://#diff-af5680cbde1fbca404443e5347bb0e99dc8838f31db22eef370f478593a6675eL178-R178) [[2]](diffhunk://#diff-a77f386cedbd3d817db1f18b205b2852ecf523d58d8ccdb251f5e32e4bec0733L9-R14)

* **Exchange Information:**
  - Updated links for the `exchangeInfo` endpoint for both REST and WebSocket APIs to align with the new documentation structure. (`docs/binance/spot/change_log.md`, `docs/binance/spot/fix_api.md`) [[1]](diffhunk://#diff-af5680cbde1fbca404443e5347bb0e99dc8838f31db22eef370f478593a6675eL591-R594) [[2]](diffhunk://#diff-24bab40ffdb2b88a5b62ffb0dc80c8592b0e999f94b4c77621f3d3fdda1768bfL1184-R1184)