### PR TITLE
Crypto.com API Documentation Update

### DIFF
--- a/docs/cryptocom/private_rest_api.md
+++ b/docs/cryptocom/private_rest_api.md
@@ -53,6 +53,11 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-06-10
+
+  - `private/amend-order` was added
+  - `public/get-announcements` was added
+
 - 2025-05-29
 
   - transaction_time_ns field was added into `user.order.{instrument_name}`
@@ -1529,6 +1534,107 @@ POST
 | ---------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | order_id   | string of number | Newly created order ID                                                                                                                                                            |
 | client_oid | string           | If a Client Order ID was provided in the request, otherwise, will be the `nonce` in the request. As nonce can be the same among orders, it is recommened to specify `client_oid`. |
+
+## private/amend-order
+
+> Request Sample (amend by order_id)
+
+    {
+        "id": 53,
+        "method": "private/amend-order",
+        "api_key": ${api_key},
+        "params": {
+            "order_id": order_id,
+            "new_price": "82000",
+            "new_quantity": "0.0002",
+        },
+        "nonce": 1587846358253
+    }
+
+> Response Sample (amend by order_id)
+
+    {
+        "id": 53,
+        "method": "private/amend-order",
+        "code": 0,
+        "result": {
+            "client_oid": "53",
+            "order_id": "6530219466236720401"
+        }
+    }
+
+> Request Sample (amend by orig_client_id)
+
+    {
+        "id": 55,
+        "method": "private/amend-order",
+        "api_key": ${api_key},
+        "params": {
+            "orig_client_oid": "53",
+            "new_price": "83000",
+            "new_quantity": "0.0001",
+        },
+        "nonce": 1587846358253
+    }
+
+> Response Sample (amend by orig_client_id)
+
+    {
+        "id": 55,
+        "method": "private/amend-order",
+        "code": 0,
+        "result": {
+            "client_oid": "55",
+            "order_id": "6530219466236720401"
+        }
+    }
+
+Amend an existing order on the Exchange.
+
+This call is asynchronous, so the response is simply a confirmation of the
+request.
+
+The `user.order` subscription can be used to check when the order is
+successfully created.
+
+Please note that amend order is designed as a convenience function such that it
+performs cancel and then create behind the scene. Original order priority will
+be cancelled with the new one created. For faster performance, it is recommended
+to use `private/cancel-order`, and then `private/create-order` instead.
+
+### Request Params
+
+| Name                                                   | Type             | Required | Description                       |
+| ------------------------------------------------------ | ---------------- | -------- | --------------------------------- |
+| Order_id                                               | string of number | Depends  | Optional Order ID                 |
+| Either `order_id` or `orig_client_oid` must be present |
+| orig_client_oid                                        | string           | Depends  | Optional Original Client Order ID |
+
+Either `order_id` or `orig_client_oid` must be present  
+If both exist together, `order_id` will have higher priority | | new_price |
+string | Y | The new amended price  
+If no change required, input original value | | new_quantity | string | Y | The
+new amended quantity  
+If no change required, input original value |
+
+Remark:  
+Either `new_price` or `new_quantity` must input a new value, otherwise request
+will be rejected.
+
+### Applies To
+
+REST Websocket (User API)
+
+### REST Method
+
+POST
+
+### Response Attributes
+
+| Name       | Type   | Description     |
+| ---------- | ------ | --------------- |
+| client_oid | string | client order ID |
+| order_id   | string | order ID        |
 
 ## private/cancel-order
 

--- a/docs/cryptocom/public_rest_api.md
+++ b/docs/cryptocom/public_rest_api.md
@@ -53,6 +53,11 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-06-10
+
+  - `private/amend-order` was added
+  - `public/get-announcements` was added
+
 - 2025-05-29
 
   - transaction_time_ns field was added into `user.order.{instrument_name}`
@@ -827,6 +832,81 @@ The original request will be returned as an escaped string in the `original`
 field.
 
 # Reference and Market Data API
+
+## public/get-announcements
+
+> Request Sample
+
+    https://api.crypto.com/v1/public/get-announcements?category=system&product_type=Spot
+
+> Response Sample
+
+    {
+      "id": 0,
+      "method": "public/get-announcements",
+      "code": 0,
+      "result": {
+        "data": [
+          {
+            "id": "67ea25c534909545bfc81232",
+            "category": "system",
+            "product_type": "Spot,Margin,Derivative,TradingArena,VIPProgramme,MMProgramme,Supercharger,TradingBot,Documents,DefiStaking,Staking,LiquidStaking,Affiliate,Referral,CROLockup,AccountManagement,OtcConvert,Transfer,ZeroFeeToken",
+            "announced_at": 1743379200000,
+            "title": "No Otc, lending, broker, affiliate_dashboard",
+            "content": "<p>test system</p>",
+            "instrument_name": null,
+            "impacted_params": {
+              "spot_trading_impacted": "PARTIAL",
+              "derivative_trading_impacted": "BAU",
+              "margin_trading_impacted": "BAU",
+              "otc_trading_impacted": "PARTIAL",
+              "convert_impacted": "PARTIAL",
+              "staking_impacted": "PARTIAL",
+              "trading_bot_impacted": "PARTIAL",
+              "crypto_wallet_impacted": "PARTIAL",
+              "fiat_wallet_impacted": "PARTIAL",
+              "login_impacted": "PARTIAL"
+            },
+            "start_time": 1743426900000,
+            "end_time": 1743434100000
+          }
+        ]
+      }
+    }
+
+Production endpoint: https://api.crypto.com/v1/public/get-announcements
+
+This api fetches all announcements in [Crypto.com](https://crypto.com/) Exchange
+
+### Request Params
+
+| Name         | Type   | Required | Description                                                                   |
+| ------------ | ------ | -------- | ----------------------------------------------------------------------------- |
+| category     | string | N        | filter by category: list, delist, event, product, system                      |
+| product_type | string | N        | filter by product type. e.g. Spot, Derivative, OTC, Staking, TradingArena etc |
+
+### Response Attributes
+
+| Name            | Type   | Description                        |
+| --------------- | ------ | ---------------------------------- |
+| id              | string | announcement id                    |
+| category        | string | type of announcement               |
+| product_type    | string | type of product                    |
+| announced_at    | string | announced timestamps               |
+| title           | string | title of announcement              |
+| content         | string | content of announcement            |
+| instrument_name | string | instrument name                    |
+| impacted_params | map    | impacted params                    |
+| start_time      | long   | announcements start time timestamp |
+| end_time        | long   | announcements end time timestamp   |
+
+### Applies To
+
+REST
+
+### REST Method
+
+GET
 
 ## public/get-risk-parameters
 

--- a/docs/cryptocom/websocket_api.md
+++ b/docs/cryptocom/websocket_api.md
@@ -53,6 +53,11 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-06-10
+
+  - `private/amend-order` was added
+  - `public/get-announcements` was added
+
 - 2025-05-29
 
   - transaction_time_ns field was added into `user.order.{instrument_name}`


### PR DESCRIPTION
**PR Summary: Cryptocurrency Exchange API Documentation Updates**

- **New Endpoints Added**
  - `private/amend-order` (Private REST & WebSocket API)
    - Allows users to amend existing orders by order ID or original client order ID.
    - Includes detailed request/response samples, parameter descriptions, and usage notes.
    - Clarifies that the endpoint performs a cancel and create operation behind the scenes.
  - `public/get-announcements` (Public REST API)
    - Provides access to exchange announcements with filtering options by category and product type.
    - Includes request/response examples and a full list of response attributes.

- **Change Logs Updated**
  - All relevant documentation files now reflect the addition of these endpoints in their change logs.

**Summary of Changes**
- Added comprehensive documentation for two new endpoints, including usage instructions, parameters, and sample payloads.
- Improved clarity and completeness of the API documentation for both private and public endpoints.