### PR TITLE
OKX API Documentation Update

### DIFF
--- a/docs/okx/public_market_data_rest_api.md
+++ b/docs/okx/public_market_data_rest_api.md
@@ -227,13 +227,9 @@ Retrieve settlement records of futures in the last 3 months.
 
 Retrieve funding rate.
 
-#### Rate Limit: 20 requests per 2 seconds
+#### Rate Limit: 10 requests per 2 seconds
 
-#### Rate limit rule: IP + Instrument ID (if instId ≠ ANY)
-
-#### Rate Limit: 1 requests per 2 seconds
-
-#### Rate limit rule: IP + Instrument ID (if instId = ANY)
+#### Rate limit rule: IP + Instrument ID
 
 #### HTTP Request
 


### PR DESCRIPTION
- Updated the "Retrieve funding rate" endpoint documentation in the OKX Public Market Data REST API.
- Consolidated and clarified rate limit information:
  - Changed rate limit to 10 requests per 2 seconds.
  - Simplified rate limit rule to "IP + Instrument ID".
- Removed previous distinctions based on the value of `instId`.
- Improved documentation clarity and consistency regarding rate limits for this endpoint.