### PR TITLE
Crypto.com API Documentation Update

### DIFF
--- a/docs/cryptocom/private_rest_api.md
+++ b/docs/cryptocom/private_rest_api.md
@@ -1598,9 +1598,10 @@ The `user.order` subscription can be used to check when the order is
 successfully created.
 
 Please note that amend order is designed as a convenience function such that it
-performs cancel and then create behind the scene. Original order priority will
-be cancelled with the new one created. For faster performance, it is recommended
-to use `private/cancel-order`, and then `private/create-order` instead.
+performs cancel and then create behind the scene. The new order will lose queue
+priority, except if the amend is only to amend down order quantity. For faster
+performance, it is recommended to use `private/cancel-order`, and then
+`private/create-order` instead.
 
 ### Request Params
 


### PR DESCRIPTION
- **Section Updated:** Amend Order (within Private REST API documentation)
- **Type of Change:** Documentation improvement/clarification
- **Details:**
  - Clarified the behavior of the amend order endpoint regarding order queue priority.
  - Specified that the new order will lose queue priority except when only reducing the order quantity.
  - Reiterated the recommendation to use `private/cancel-order` followed by `private/create-order` for better performance.