### PR TITLE
Bitget API Documentation Update

### DIFF
--- a/docs/bitget/change_log.md
+++ b/docs/bitget/change_log.md
@@ -2,6 +2,13 @@
 
 ## Changelog
 
+### \[Jun 16, 2025\] The ADL ranking interface has added the position direction.[​](#jun-16-2025-the-adl-ranking-interface-has-added-the-position-direction "Direct link to jun-16-2025-the-adl-ranking-interface-has-added-the-position-direction")
+
+Interface：/api/v2/mix/position/adlRank  
+Changes：
+
+- The ADL ranking interface has added the position direction `holdSide` field。
+
 ### \[June 09, 2025\] Get Contract Information Adds Maximum Order Quantity Fields[​](#june-09-2025-get-contract-information-adds-maximum-order-quantity-fields "Direct link to june-09-2025-get-contract-information-adds-maximum-order-quantity-fields")
 
 Interface：/api/v2/mix/market/contracts  

--- a/docs/bitget/futures_api.md
+++ b/docs/bitget/futures_api.md
@@ -1054,6 +1054,7 @@ Response Example
 | &gt; maintainTime           | String             | Maintenance time (there will be a value when the status is under maintenance/upcoming maintenance)                                                                                                                                                                                                         |
 | &gt; maxMarketOrderQty      | String             | Maximum order quantity for a single market order<br>This refers to the maximum allowed quantity when placing an order using the base coin                                                                                                                                                                  |
 | &gt; maxOrderQty            | String             | Maximum order quantity for a single limit order<br>This refers to the maximum allowed quantity when placing an order using the base coin                                                                                                                                                                   |
+| &gt; openTime               | String             | This field has been deprecated                                                                                                                                                                                                                                                                             |
 
 > **Source:**
 > [original URL](https://www.bitget.com/api-doc/contract/market/Get-All-Symbols-Contracts)


### PR DESCRIPTION
**PR Summary: Bitget API Documentation Updates**

- **/api/v2/mix/position/adlRank**
  - Added documentation for the new response field `holdSide`, indicating the position direction in the ADL ranking interface.

- **/api/v2/mix/market/contracts**
  - Noted that the `openTime` field in the response has been deprecated.

- **General**
  - Updated the changelog to reflect the above changes.