### PR TITLE
BingX API Documentation Update

### DIFF
--- a/docs/bingx/spot/change_log.md
+++ b/docs/bingx/spot/change_log.md
@@ -2,6 +2,11 @@
 
 ## Change Log
 
+2025-06-17
+
+- USDT-M Perp Futures: Websocket ‘Market Depth Data’ push intervals adjusted to
+  200ms and 500ms.
+
 2025-06-12
 
 - USDT-M Perp Futures: The order placement API response now includes an


### PR DESCRIPTION
- Updated the change log for BingX Spot API documentation.
- Documented adjustment of WebSocket "Market Depth Data" push intervals for USDT-M Perp Futures to 200ms and 500ms.
- No new endpoints or parameter changes; update is informational regarding data delivery intervals.