### PR TITLE
Bitmart API Documentation Update

### DIFF
--- a/docs/bitmart/futures/basic_information.md
+++ b/docs/bitmart/futures/basic_information.md
@@ -96,7 +96,8 @@ The speed of the public interface is limited according to the IP, and the speed 
 | /contract/public/funding-rate-history | Get history Funding Rate | IP | 12 times/2 sec 
 | /contract/public/kline | Get K-line | IP | 12 times/2 sec 
 | /contract/public/markprice-kline | Get Mark Price K-line | IP | 12 times/2 sec 
-| /contract/public/leverage-bracket | Get Contract Leverage Risk Limit | IP | 12次/2s 
+| /contract/public/leverage-bracket | Get Contract Leverage Risk Limit | IP | 12 times/2 sec 
+| /contract/public/market-trade | Get Market Trade | IP | 12 times/2 sec 
 
 | Futures Trade Endpoints | Endpoint Name | Limit Target | Rate |
 | --- | --- | --- | --- |

--- a/docs/bitmart/futures/change_log.md
+++ b/docs/bitmart/futures/change_log.md
@@ -1,5 +1,14 @@
 # Change Log
 
+#### 2025-06-20
+
+###### REST API
+
+*   \[New\] `/contract/public/market-trade` Query the latest trade data
+    *   Feat: Retrieve up to the most recent 100 trade records
+
+* * *
+
 #### 2025-06-05
 
 ###### REST API

--- a/docs/bitmart/futures/futures_market_data.md
+++ b/docs/bitmart/futures/futures_market_data.md
@@ -113,6 +113,44 @@ Market depth details：
 | The second | String | Total quantity of current price depth. For example 65 
 | The third | String | Accumulates the total quantity above (including) the current price depth. For example 65 
 
+## Get Market Trade
+
+`Query the latest trade data`
+
+#### Request URL
+
+`GET https://api-cloud-v2.bitmart.com/contract/public/market-trade`
+
+#### Request Limit
+
+See [Detailed Rate Limit](#rate-limit)
+
+#### Request Parameter
+
+> Request
+
+`curl https://api-cloud-v2.bitmart.com/contract/public/market-trade?symbol=BTCUSDT&limit=100`
+
+| Field | Type | Required? | Description |
+| --- | --- | --- | --- |
+| symbol | String | Yes | Symbol of the contract(like BTCUSDT) 
+| limit | Long | No | Count(Default 50; max 100;) 
+
+#### Response Data
+
+> Response
+
+`{   "code": 1000,   "message": "Ok",   "data": [     {       "symbol": "BTCUSDT",       "price": "104146.5",       "qty": "0.037",       "quote_qty": "3853.4205",       "time": 1750347973,       "is_buyer_maker": true     },     {       "symbol": "BTCUSDT",       "price": "104146.6",       "qty": "0.023",       "quote_qty": "2395.3718",       "time": 1750347972,       "is_buyer_maker": true     }   ],   "trace": "26f999a04cfa11f09ce9d6002fd59247.4375416.39621015744567440" }`
+
+| Field | Type | Description |
+| --- | --- | --- |
+| symbol | String | Symbol 
+| price | String | Trade price 
+| qty | String | Trade value - coin 
+| quote_qty | String | Trade value - USDT 
+| time | Long | Market trade time stamp 
+| is_buyer_maker | Bool | True if Buyer of the trade is maker 
+
 ## Get Futures Openinterest
 
 `Applicable for querying the open interest and open interest value data of the specified contract`


### PR DESCRIPTION
**PR Summary: BitMart Futures API Documentation Updates**

- **New Endpoint Added**
  - Introduced the `/contract/public/market-trade` REST API endpoint for querying the latest market trade data.
    - Allows retrieval of up to 100 most recent trade records.
    - Documented request parameters (`symbol`, `limit`) and response fields.

- **Documentation Improvements**
  - Added detailed documentation for the new endpoint in the "Futures Market Data" section, including example requests and response structure.
  - Updated the rate limit table in the "Basic Information" section to include `/contract/public/market-trade` (12 times/2 sec).
  - Corrected language in the rate limit table for `/contract/public/leverage-bracket` from Chinese to English for consistency.

- **Change Log Updated**
  - Added an entry for the new endpoint in the change log, detailing its functionality and availability as of 2025-06-20.