### PR TITLE
Binance USDM API Documentation Update

### DIFF
--- a/docs/binance/usdm/private_rest_api.md
+++ b/docs/binance/usdm/private_rest_api.md
@@ -868,7 +868,7 @@ Different accounts with the same `tradeGroupId` are considered part of the same
 according to the taker-order's STP mode.
 
 A user can confirm if their accounts are under the same `tradeGroupId` from the
-API either from `GET fapi/v3/account` (REST API).
+API either from `GET /fapi/v1/accountConfig` (REST API).
 
 If the value is `-1`, then the `tradeGroupId` has not been set for that account,
 so the STP may only take place between orders of the same account.

--- a/docs/binance/usdm/public_rest_api.md
+++ b/docs/binance/usdm/public_rest_api.md
@@ -1145,14 +1145,14 @@ NONE
   "assets": [
     // assets information
     {
-      "asset": "BUSD",
+      "asset": "BTC",
       "marginAvailable": true, // whether the asset can be used as margin in Multi-Assets mode
-      "autoAssetExchange": 0 // auto-exchange threshold in Multi-Assets margin mode
+      "autoAssetExchange": "-0.10" // auto-exchange threshold in Multi-Assets margin mode
     },
     {
       "asset": "USDT",
       "marginAvailable": true,
-      "autoAssetExchange": 0
+      "autoAssetExchange": "0"
     },
     {
       "asset": "BNB",
@@ -1216,7 +1216,7 @@ NONE
           "filterType": "PERCENT_PRICE",
           "multiplierUp": "1.1500",
           "multiplierDown": "0.8500",
-          "multiplierDecimal": 4
+          "multiplierDecimal": "4"
         }
       ],
       "OrderType": [


### PR DESCRIPTION
**PR Summary: Binance USDⓈ-M Futures API Documentation Updates**

- **Private REST API**
  - Corrected the endpoint reference for checking `tradeGroupId` status from `GET fapi/v3/account` to `GET /fapi/v1/accountConfig`.

- **Public REST API**
  - Updated example responses in the assets section:
    - Changed example asset from "BUSD" to "BTC".
    - Updated `autoAssetExchange` example values from numeric (`0`) to string format (e.g., `"-0.10"`, `"0"`).
  - Modified the `multiplierDecimal` field in the filters example from numeric (`4`) to string (`"4"`).

**Summary of changes:**  
- Improved accuracy of endpoint references.
- Updated example response data types and values for better clarity and consistency.