### PR TITLE
Bitget API Documentation Update

### DIFF
--- a/docs/bitget/futures_api.md
+++ b/docs/bitget/futures_api.md
@@ -1998,6 +1998,24 @@ Response
   latest reduce-only order request will not include an `orderId`. You can use
   the `clientOid` set in the request to query order details or retrieve the
   orderId from the current pending orders.
+- When in `hedge Mode`, if a limit close order is occupying a position, and a
+  subsequent market close order (its quantity plus the limit order's quantity)
+  exceeds the total position size, it will not report an insufficient position
+  error. It also won't cancel the limit order that's occupying the position.
+  Instead, the quantity of the limit close order will be preserved, and the
+  market order will close only the quantity remaining after subtracting the
+  limit order's quantity from the total position size. For example: If you have
+  a position of 100, a limit order occupies 70, and you then place a market
+  close order for 50, it will not report an insufficient position error, nor
+  will it cancel the occupying limit order to execute the market order. Instead,
+  it will directly close a quantity of 30.
+- When in `hedge Mode`, if a limit close order is occupying a position, and the
+  quantity of the limit close order is equal to the total position size, then
+  any subsequent market close order will report an insufficient position error.
+  It will not cancel the limit order that's occupying the position. For example:
+  If you have a position of 100, a limit order occupies 100, and you then place
+  a market close order for 50, it will report an insufficient position error and
+  will not cancel the occupying limit order to execute the market order.
 - For elite traders, please strictly adhere to the list of trading pairs
   specified in the
   [Available trading pairs and parameters for elite traders](https://www.bitget.com/zh-CN/support/articles/12560603808895)

--- a/docs/bitget/spot_api.md
+++ b/docs/bitget/spot_api.md
@@ -1021,7 +1021,7 @@ curl "https://api.bitget.com/api/v2/spot/trade/unfilled-orders?symbol=BTCUSDT&st
 Response Example
 
 ```
-{  "code": "00000",  "message": "success",  "requestTime": 1695808949356,  "data": [    {      "userId": "**********",      "symbol": "btcusdt",      "orderId": "2222222",      "clientOid": "xxxxxxx",      "priceAvg": "34829.12",      "size": "1",      "orderType": "limit",      "side": "buy",      "status": "new",      "basePrice": "0",      "baseVolume": "0",      "quoteVolume": "0",      "enterPointSource": "WEB",      "presetTakeProfitPrice": "70000",      "executeTakeProfitPrice": "",      "presetStopLossPrice": "10000",      "executeStopLossPrice": "",      "cTime": "1622697148",      "tpslType": "normal",      "triggerPrice": null    }  ]}
+{  "code": "00000",  "msg": "success",  "requestTime": 1695808949356,  "data": [    {      "userId": "**********",      "symbol": "btcusdt",      "orderId": "2222222",      "clientOid": "xxxxxxx",      "priceAvg": "34829.12",      "size": "1",      "orderType": "limit",      "side": "buy",      "status": "new",      "basePrice": "0",      "baseVolume": "0",      "quoteVolume": "0",      "enterPointSource": "WEB",      "presetTakeProfitPrice": "70000",      "executeTakeProfitPrice": "",      "presetStopLossPrice": "10000",      "executeStopLossPrice": "",      "cTime": "1622697148",      "tpslType": "normal",      "triggerPrice": null    }  ]}
 ```
 
 #### Response Parameter[​](#response-parameter "Direct link to Response Parameter")


### PR DESCRIPTION
**PR Summary: Bitget API Documentation Updates**

- **Futures API (`futures_api.md`):**
  - Improved documentation for order handling in Hedge Mode:
    - Added detailed explanations and examples regarding the behavior when both limit and market close orders are placed and their combined quantities exceed or match the total position size.
    - Clarified error handling and order preservation logic in these scenarios.

- **Spot API (`spot_api.md`):**
  - Updated response example for the `GET /api/v2/spot/trade/unfilled-orders` endpoint:
    - Changed the response field from `"message"` to `"msg"` to accurately reflect the API's actual response format.

These changes enhance clarity around order management logic in Hedge Mode for futures and ensure response examples for spot trading endpoints are accurate and up-to-date.