### PR TITLE
Bitmart API Documentation Update

### DIFF
--- a/docs/bitmart/futures/futures_trading.md
+++ b/docs/bitmart/futures/futures_trading.md
@@ -87,8 +87,8 @@ See [Detailed Rate Limit](#rate-limit)
 | preset_stop_loss_price_type | Int | Pre-set SL price type<br>-<code>1</code>=last_price<br>-<code>2</code>=fair_price 
 | preset_take_profit_price | String | Pre-set TP price 
 | preset_stop_loss_price | String | Pre-set SL price 
-| create_time | Long | Create time 
-| update_time | Long | Update time 
+| create_time | Long | Order created timestamp (ms) 
+| update_time | Long | Latest transaction timestamp (ms) 
 
 ## Get Order History (KEYED)
 
@@ -150,8 +150,8 @@ See [Detailed Rate Limit](#rate-limit)
 | preset_stop_loss_price_type | Int | Pre-set SL price type<br>-<code>0</code>=unset<br>-<code>1</code>=last_price<br>-<code>2</code>=fair_price 
 | preset_take_profit_price | String | Pre-set TP price 
 | preset_stop_loss_price | String | Pre-set SL price 
-| create_time | Long | Create time 
-| update_time | Long | Update time 
+| create_time | Long | Order created timestamp (ms) 
+| update_time | Long | Order updated timestamp (ms) 
 
 ## Get All Open Orders (KEYED)
 
@@ -207,8 +207,8 @@ See [Detailed Rate Limit](#rate-limit)
 | preset_stop_loss_price_type | Int | Pre-set SL price type<br>-<code>1</code>=last_price<br>-<code>2</code>=fair_price 
 | preset_take_profit_price | String | Pre-set TP price 
 | preset_stop_loss_price | String | Pre-set SL price 
-| create_time | Long | Create time 
-| update_time | Long | Update time 
+| create_time | Long | Order created timestamp (ms) 
+| update_time | Long | Order updated timestamp (ms) 
 
 ## Get All Current Plan Orders (KEYED)
 
@@ -263,8 +263,8 @@ See [Detailed Rate Limit](#rate-limit)
 | preset_stop_loss_price_type | Int | Pre-set SL price type<br>-<code>1</code>=last_price<br>-<code>2</code>=fair_price 
 | preset_take_profit_price | String | Pre-set TP price 
 | preset_stop_loss_price | String | Pre-set SL price 
-| create_time | Long | Create time 
-| update_time | Long | Update time 
+| create_time | Long | Order created timestamp (ms) 
+| update_time | Long | Order updated timestamp (ms) 
 
 ## Get Current Position (KEYED)
 
@@ -318,7 +318,7 @@ See [Detailed Rate Limit](#rate-limit)
 | realized_value | String | Realized PnL 
 | position_type | Int | position type<br>-<code>1</code>=long<br>-<code>2</code>=short 
 | account | String | Trading account<br>-<code>futures</code><br>-<code>copy_trading</code> 
-| timestamp | Long | Current timestamp 
+| timestamp | Long | Current timestamp(ms) 
 
 ## Get Current Position V2 (KEYED)
 
@@ -383,7 +383,7 @@ See [Detailed Rate Limit](#rate-limit)
 | realized_value | String | Realized PnL 
 | initial_margin | String | Position margin 
 | account | String | Trading account<br>-<code>futures</code><br>-<code>copy_trading</code> 
-| timestamp | Long | Current timestamp 
+| timestamp | Long | Current timestamp(ms) 
 
 ## Get Current Position Risk Details(KEYED)
 
@@ -481,7 +481,7 @@ See [Detailed Rate Limit](#rate-limit)
 | realised_profit | String | realised profit 
 | paid_fees | String | paid fees 
 | account | String | Trading account<br>-<code>futures</code><br>-<code>copy_trading</code> 
-| create_time | Long | Create time 
+| create_time | Long | Transaction create timestamp (ms) 
 
 ## Get Transaction History (KEYED)
 
@@ -527,7 +527,7 @@ See [Detailed Rate Limit](#rate-limit)
 | account | String | Trading account<br>-<code>futures</code><br>-<code>copy_trading</code> 
 | amount | String | Amount, supports positive and negative values 
 | asset | String | Transaction currency 
-| time | String | Transaction time, timestamp in ms 
+| time | String | Transaction timestamp, timestamp in ms 
 | tran_id | String | Transaction ID 
 
 ## Get Transfer List (SIGNED)

--- a/docs/bitmart/futures/websocket_subscription.md
+++ b/docs/bitmart/futures/websocket_subscription.md
@@ -294,7 +294,7 @@ Return data description:
 | symbol | String | Symbol of the contract(like <code>BTCUSDT</code>) 
 | way | Long | Trading side<br>-<code>1</code>=bid<br>-<code>2</code>=ask 
 | depths | List | Array of depth details 
-| ms_t | Long | Timestamp (in millisecond) 
+| ms_t | Long | Data push timestamp (in millisecond) 
 
 **Instruction**
 
@@ -353,7 +353,7 @@ Return data description:
 | symbol | String | Symbol of the contract（like <code>BTCUSDT</code>） 
 | asks | List | Asks Depth Array 
 | bids | List | Bids Depth Array 
-| ms_t | Long | Timestamp (in millisecond) 
+| ms_t | Long | Data push timestamp (in millisecond) 
 
 **Instruction** Description of the `asks` `bids` details field:
 
@@ -419,7 +419,7 @@ Return data description:
 | symbol | String | Symbol of the contract (like <code>BTCUSDT</code>) 
 | asks | List | Asks Depth Array 
 | bids | List | Bids Depth Array 
-| ms_t | Long | Timestamp (in millisecond) 
+| ms_t | Long | Data push timestamp (in millisecond) 
 | version | Long | data version 
 | type | String | data type<br>-<code>snapshot</code>=Full depth snapshot data<br>-<code>update</code>=Incremental depth data 
 
@@ -491,7 +491,7 @@ Return data description:
 | best_bid_vol | String | Best bid volume 
 | best_ask_price | String | Best ask price 
 | best_ask_vol | String | Best ask volume 
-| ms_t | Long | Timestamp (in millisecond) 
+| ms_t | Long | Data push timestamp (in millisecond) 
 
 * * *
 
@@ -534,7 +534,7 @@ Return data description:
 | deal_vol | String | deal vol 
 | way | Int | Trading type<br>-<code>1</code>=buy_open_long sell_open_short<br>-<code>2</code>=buy_open_long sell_close_long<br>-<code>3</code>=buy_close_short sell_open_short<br>-<code>4</code>=buy_close_short sell_close_long<br>-<code>5</code>=sell_open_short buy_open_long<br>-<code>6</code>=sell_open_short buy_close_short<br>-<code>7</code>=sell_close_long buy_open_long<br>-<code>8</code>=sell_close_long buy_close_short 
 | m | Bool | -<code>true</code>=buyer is maker<br>-<code>false</code>=seller is maker 
-| created_at | String | create time 
+| created_at | String | transaction create time(ms) 
 
 ## 【Public】KlineBin Channel
 
@@ -588,7 +588,7 @@ Return data description:
 | l | String | Lowest Price 
 | c | String | Closing Price 
 | v | String | Turnover 
-| ts | Long | Timestamp 
+| ts | Long | K-line timestamp（in second） 
 
 ## 【Public】MarkPrice KlineBin Channel
 
@@ -642,7 +642,7 @@ Return data description:
 | l | String | Lowest Price 
 | c | String | Closing Price 
 | v | String | Turnover 
-| ts | Long | Timestamp 
+| ts | Long | Data push timestamp (in second) 
 
 ## 【Private】Login
 
@@ -770,8 +770,8 @@ Return data description:
 | close_avg_price | String | Average close price 
 | open_avg_price | String | Average opening price 
 | liquidate_price | String | Liquidation price 
-| create_time | Long | Create time 
-| update_time | Long | Update time 
+| create_time | Long | Position created timestamp (ms) 
+| update_time | Long | Position updated timestamp (ms) 
 | position_mode | String | Position mode<br>-<code>hedge_mode</code><br>-<code>one_way_mode</code> 
 
 ## 【Private】Order Channel
@@ -818,8 +818,8 @@ Return data description:
 | deal_size | String | Deal amount 
 | price | String | Consignment price 
 | state | Int | Order status<br>-<code>1</code>=status_approval<br>-<code>2</code>=status_check<br>-<code>4</code>=status_finish 
-| create_time | Long | Create time 
-| update_time | Long | Update time 
+| create_time | Long | Order created timestamp (ms) 
+| update_time | Long | Order updated timestamp (ms) 
 | plan_order_id | String | Trigger plan order id 
 | last_trade | object | recently trade info for this order，return null if not exist 
 | trigger_price | String | Trigger price of TP/SL / plan order 

--- a/docs/bitmart/spot/spot___margin_trading.md
+++ b/docs/bitmart/spot/spot___margin_trading.md
@@ -548,8 +548,8 @@ Refer to [Rate Limitation Details](#cad33537ae)
 | orderMode | String | Order mode<br>-<code>spot</code>=spot<br>-<code>iso_margin</code>=isolated margin 
 | type | String | Order type<br>-<code>limit</code>=limit order<br>-<code>market</code>=market order<br>-<code>limit_maker</code>=PostOnly order<br>-<code>ioc</code>=IOC order 
 | state | String | Order status<br>-<code>new</code>=The order has been accepted by the engine.<br>-<code>partially_filled</code>=a part of the order has been filled. 
-| cancelSource | String | Order cancellation reason(Return value only if the order state is <strong>canceled</strong> or <strong>partially_canceled</strong>, otherwise it will return an empty string)<br>-<code>user</code>=User manually canceled.<br>-<code>system</code>=System automatically canceled.<br>-<code>stp</code>=Stp Cancelled. 
-| stpMode | String | Self transaction protection type<br>-<code>none</code>=none<br>-<code>cancel_maker</code>=cancel_maker<br>-<code>cancel_taker</code>=cancel_taker<br>-<code>cancel_both</code>=cancel_both 
+| cancelSource | String | Order cancellation reason(Return value only if the order state is <strong>canceled</strong> or <strong>partially_canceled</strong>, otherwise it will return an empty string)<br>-<code>user</code>=User manually canceled.<br>-<code>system</code>=System automatically canceled. 
+| stpMode | String | 自成交保护类型<br>-<code>none</code>=不使用<br>-<code>cancel_maker</code>=撤销maker<br>-<code>cancel_taker</code>=撤销taker<br>-<code>cancel_both</code>=全部撤销 
 | price | String | Order price 
 | priceAvg | String | Average execution price of the order 
 | size | String | Order quantity 

--- a/docs/bitmart/spot/websocket_subscription.md
+++ b/docs/bitmart/spot/websocket_subscription.md
@@ -264,7 +264,7 @@ Return data description:
 | base_volume_24h | String | 24-hour traded volume in base currency 
 | quote_volume_24h | String | 24-hour traded volume in quote currency 
 | s_t | Long | Create Time (timestamp in seconds) (The field will be removed, please use the ms_t field) 
-| ms_t | Long | Create Time (timestamp in millisecond) 
+| ms_t | Long | Data push Timestamp (timestamp in millisecond) 
 | fluctuation | String | 24-hour Price change 
 | bid_px | String | Best bid price 
 | bid_sz | String | Best bid quantity 
@@ -384,7 +384,7 @@ Return data description:
 | symbol | String | Trading pair, <code>BTC_USDT</code> 
 | asks | List<string></string> | Ask depth 
 | bids | List<string></string> | Bid depth 
-| ms_t | Long | Timestamp (in millisecond) 
+| ms_t | Long | Data push Timestamp (Timestamp in millisecond) 
 
 An example of the array of asks and bids values: \["161.96","7.37567"\], 161.96 is the price, and 7.37567 is the quantity.
 
@@ -441,7 +441,7 @@ Return data description:
 | symbol | String | Trading pair, <code>BTC_USDT</code> 
 | asks | List<string></string> | Ask depth 
 | bids | List<string></string> | Bid depth 
-| ms_t | Long | Timestamp (in millisecond) 
+| ms_t | Long | Data push Timestamp (Timestamp in millisecond) 
 | version | Long | data version 
 | type | String | data type<br>-<code>snapshot</code>=Full depth snapshot data<br>-<code>update</code>=Incremental depth data 
 
@@ -642,8 +642,8 @@ Return data description:
 | exec_type | string | Whether the trade was created by a maker or a taker.<br>-<code>M</code>=Maker<br>-<code>T</code>=Taker 
 | detail_id | string | Trade id 
 | client_order_id | string | Client-defined OrderId 
-| create_time | String | Order Create Time (in milliseconds) 
-| update_time | String | Order Update Time (in milliseconds) 
+| create_time | String | Order Create Timestamp (in milliseconds) 
+| update_time | String | Order Update Timestamp (in milliseconds) 
 | order_mode | String | Order mode<br>-<code>spot</code>=spot<br>-<code>iso_margin</code>=margin 
 | entrust_type | String | Order Type<br>-<code>NORMAL</code>=Normal trade order(Limit Order or Market Order)<br>-<code>LIMIT_MAKER</code>=PostOnly Order<br>-<code>IOC</code>=IOC Order 
 | order_state | String | Order State<br>-<code>new</code>=The order has been accepted by the engine.<br>-<code>partially_filled</code>=A part of the order has been filled.<br>-<code>filled</code>=The order has been completed.<br>-<code>canceled</code>=The order has been canceled by the user.<br>-<code>partially_canceled</code>=A part of the order has been filled , and the order has been canceled. 


### PR DESCRIPTION
**PR Summary: BitMart API Documentation Updates**

- **Futures Trading REST API (`futures_trading.md`):**
  - Improved descriptions for several timestamp-related response fields (e.g., `create_time`, `update_time`, `timestamp`) to clarify their meaning and units (milliseconds).
  - Updated field descriptions for order and transaction history endpoints to specify whether timestamps refer to order creation, update, or transaction times.

- **Futures Websocket API (`websocket_subscription.md`):**
  - Enhanced timestamp field descriptions (e.g., `ms_t`, `created_at`, `ts`, `create_time`, `update_time`) to clarify their purpose (such as "data push timestamp" or "transaction create time (ms)").
  - Clarified units (milliseconds or seconds) and context for K-line and order/position fields.

- **Spot Margin Trading REST API (`spot___margin_trading.md`):**
  - Updated the `cancelSource` field to remove the `stp` (Self-Trade Prevention) cancellation reason from the documented values.
  - Revised the `stpMode` field description to use Chinese language and more descriptive values for self-trade protection types.

- **Spot Websocket API (`websocket_subscription.md`):**
  - Improved descriptions for timestamp fields (e.g., `ms_t`, `create_time`, `update_time`) to specify "data push timestamp" and clarify units.
  - Updated order-related fields to use "Order Create/Update Timestamp" for consistency.

**Overall:**  
These changes enhance clarity and consistency in timestamp and status field documentation across BitMart's Futures and Spot APIs, improving developer understanding and reducing ambiguity. No new endpoints were added; all changes are documentation improvements and clarifications.