### PR TITLE
Binance Spot API Documentation Update

### DIFF
--- a/docs/binance/spot/private_rest_api.md
+++ b/docs/binance/spot/private_rest_api.md
@@ -1979,6 +1979,7 @@ has not exceeded their unfilled order count:**
       "orderId": 3,
       "orderListId": -1,
       "clientOrderId": "G1kLo6aDv2KGNTFcjfTSFq",
+      "transactTime": 1684804350068,
       "price": "0.006123",
       "origQty": "10000.000000",
       "executedQty": "0.000000",

--- a/docs/binance/spot/private_websocket_api.md
+++ b/docs/binance/spot/private_websocket_api.md
@@ -3735,6 +3735,7 @@ succeeded, which failed, and why:
         "orderId": 125690984230,
         "orderListId": -1,
         "clientOrderId": "91fe37ce9e69c90d6358c0",
+        "transactTime": 1684804350068,
         "price": "23450.00000000",
         "origQty": "0.00847000",
         "executedQty": "0.00001000",


### PR DESCRIPTION
This pull request updates the Binance Spot API documentation by adding the `transactTime` field to both REST and WebSocket API examples. This change ensures consistency and provides additional information about transaction timings.

Updates to API documentation:

* [`docs/binance/spot/private_rest_api.md`](diffhunk://#diff-0fd860f4c27103a1db4f0a313d2e261bcc9a615ec0c015a59f6d85b040af8a9aR1982): Added the `transactTime` field to the REST API example to include the transaction timestamp.
* [`docs/binance/spot/private_websocket_api.md`](diffhunk://#diff-a77f386cedbd3d817db1f18b205b2852ecf523d58d8ccdb251f5e32e4bec0733R3738): Added the `transactTime` field to the WebSocket API example to include the transaction timestamp.