### PR TITLE
Crypto.com API Documentation Update

### DIFF
--- a/docs/cryptocom/private_rest_api.md
+++ b/docs/cryptocom/private_rest_api.md
@@ -3100,7 +3100,8 @@ Default: 100.
 Max: 100. |
 
 **Note**: If you omit all parameters, you still need to pass in an empty
-`params` block like `params: {}` for API request consistency
+`params` block like `params: {}` for API request consistency  
+get-trades time window can only be up to 7 days for maximum.
 
 ### Applies To
 

--- a/docs/cryptocom/public_rest_api.md
+++ b/docs/cryptocom/public_rest_api.md
@@ -1291,6 +1291,8 @@ Nanosecond is recommended for accurate pagination | | end_ts | number or string
 Default: current system timestamp.  
 Nanosecond is recommended for accurate pagination |
 
+**Note**: get-trades time window can only be up to 7 days for maximum.
+
 ### Applies To
 
 REST


### PR DESCRIPTION
## PR Summary

- Updated the documentation for the `get-trades` endpoint in both the Private and Public REST API sections.
- Added a note specifying that the maximum allowed time window for `get-trades` requests is 7 days.
- Clarified parameter usage and API request consistency in the Private REST API documentation.

## Twitter/X Update

🔔 API docs update: The `get-trades` endpoint now has a max time window of 7 days! ⏳ Please review your integrations to ensure compliance. #CryptoAPI #DevUpdate