### PR TITLE
Binance USDM API Documentation Update

### DIFF
--- a/docs/binance/usdm/private_rest_api.md
+++ b/docs/binance/usdm/private_rest_api.md
@@ -1599,6 +1599,7 @@ Codes are universal,but messages can vary.
 | 5039 | INVALID_SELF_TRADE_PREVENTION_MODE​            | Invalid self trade prevention mode                                                                                                                                                                                                                     |
 | 5040 | FUTURE_GOOD_TILL_DATE​                         | The goodTillDate timestamp must be greater than the current time plus 600 seconds and smaller than 253402300799000 (UTC 9999-12-31 23:59:59)                                                                                                           |
 | 5041 | BBO_ORDER_REJECT​                              | No depth matches this BBO order                                                                                                                                                                                                                        |
+| 5043 | BBO_ORDER_REJECT​                              | A pending modification already exists for this order.                                                                                                                                                                                                  |
 
 ### 10xx - General Server or Network issues
 

--- a/docs/binance/usdm/private_websocket_api.md
+++ b/docs/binance/usdm/private_websocket_api.md
@@ -278,6 +278,7 @@ Codes are universal,but messages can vary.
 | 5039 | INVALID_SELF_TRADE_PREVENTION_MODE​            | Invalid self trade prevention mode                                                                                                                                                                                                                     |
 | 5040 | FUTURE_GOOD_TILL_DATE​                         | The goodTillDate timestamp must be greater than the current time plus 600 seconds and smaller than 253402300799000 (UTC 9999-12-31 23:59:59)                                                                                                           |
 | 5041 | BBO_ORDER_REJECT​                              | No depth matches this BBO order                                                                                                                                                                                                                        |
+| 5043 | BBO_ORDER_REJECT​                              | A pending modification already exists for this order.                                                                                                                                                                                                  |
 
 ### 10xx - General Server or Network issues
 

--- a/docs/binance/usdm/public_rest_api.md
+++ b/docs/binance/usdm/public_rest_api.md
@@ -1034,6 +1034,7 @@ Codes are universal,but messages can vary.
 | 5039 | INVALID_SELF_TRADE_PREVENTION_MODE​            | Invalid self trade prevention mode                                                                                                                                                                                                                     |
 | 5040 | FUTURE_GOOD_TILL_DATE​                         | The goodTillDate timestamp must be greater than the current time plus 600 seconds and smaller than 253402300799000 (UTC 9999-12-31 23:59:59)                                                                                                           |
 | 5041 | BBO_ORDER_REJECT​                              | No depth matches this BBO order                                                                                                                                                                                                                        |
+| 5043 | BBO_ORDER_REJECT​                              | A pending modification already exists for this order.                                                                                                                                                                                                  |
 
 ### 10xx - General Server or Network issues
 

--- a/docs/binance/usdm/public_websocket_api.md
+++ b/docs/binance/usdm/public_websocket_api.md
@@ -1039,6 +1039,7 @@ Codes are universal,but messages can vary.
 | 5039 | INVALID_SELF_TRADE_PREVENTION_MODE​            | Invalid self trade prevention mode                                                                                                                                                                                                                     |
 | 5040 | FUTURE_GOOD_TILL_DATE​                         | The goodTillDate timestamp must be greater than the current time plus 600 seconds and smaller than 253402300799000 (UTC 9999-12-31 23:59:59)                                                                                                           |
 | 5041 | BBO_ORDER_REJECT​                              | No depth matches this BBO order                                                                                                                                                                                                                        |
+| 5043 | BBO_ORDER_REJECT​                              | A pending modification already exists for this order.                                                                                                                                                                                                  |
 
 ### 10xx - General Server or Network issues
 


### PR DESCRIPTION
## PR Summary

- Updated error code documentation across the following Binance USD-M Futures API sections:
  - Private REST API
  - Private WebSocket API
  - Public REST API
  - Public WebSocket API
- Added a new error code entry:
  - **5043 | BBO_ORDER_REJECT** — "A pending modification already exists for this order."
- This update improves clarity on order modification rejection scenarios by documenting the new error code and its message.

## Twitter/X Update

🚨 Binance USD-M Futures API docs updated! New error code 5043 (BBO_ORDER_REJECT): "A pending modification already exists for this order." Now live in REST & WebSocket docs for better clarity! #BinanceAPI #CryptoDev