### PR TITLE
Bitget API Documentation Update

### DIFF
--- a/docs/bitget/spot_api.md
+++ b/docs/bitget/spot_api.md
@@ -139,6 +139,7 @@ Response Example
 | orderQuantity       | String | The maximum number of orders allowed for the current symbol                                                                                          |
 | areaSymbol          | String | Area symbol<br><code>yes</code>, <code>no</code>                                                                                                     |
 | offTime             | String | Symbol off time, e.g: 1744797600000                                                                                                                  |
+| openTime            | String | This field has been deprecated                                                                                                                       |
 
 > **Source:**
 > [original URL](https://www.bitget.com/api-doc/spot/market/Get-Symbols)


### PR DESCRIPTION
## PR Summary

- Updated the Bitget Spot API documentation for the "Get Symbols" endpoint.
- Added documentation for the openTime response field, noting that it has been deprecated.
- No new endpoints or parameter changes; this is a documentation clarification to inform users about the deprecation status of openTime.

## Twitter/X Update

📢 Bitget Spot API docs update: The "openTime" field in the Get Symbols endpoint is now marked as deprecated. Stay up-to-date and check the docs for details! 🚀 #crypto #API #Bitget