### PR TITLE
BingX API Documentation Update

### DIFF
--- a/docs/bingx/spot/change_log.md
+++ b/docs/bingx/spot/change_log.md
@@ -2,6 +2,14 @@
 
 ## Change Log
 
+2025-06-30
+
+- USDT-M Perp Futures: Added displayName field to 'USDT-M Perp Futures symbols'
+  interface.
+- Coin-M Perp Futures: Added displayName field to 'Contract Information'
+  interface.
+- Spot: Added displayName field to 'Spot trading symbols' interface.
+
 2025-06-17
 
 - USDT-M Perp Futures: Websocket ‘Market Depth Data’ push intervals adjusted to

--- a/docs/bingx/spot/private_rest_api.md
+++ b/docs/bingx/spot/private_rest_api.md
@@ -2355,7 +2355,7 @@ account
 | 100413     | Incorrect apiKey                                                                                                                                             |
 | 100410     | over 20 error code:100202 requests within 480000 ms for this api, please verify and fix it ,can retry after time: 1727193970155                              |
 
-### Query sub-account spot assets
+### Query sub-account Fund Account
 
 GET /openApi/subAccount/v1/assets
 
@@ -2365,7 +2365,7 @@ API KEY permission: Read
 
 Content-Type:request body(application/json)
 
-To check the balance of the spot account of each currency of the sub-account.
+To check the balance of the Fund Account of each currency of the sub-account.
 The user who verifies the signature of this API must be main account
 
 #### Request Parameters

--- a/docs/bingx/spot/public_rest_api.md
+++ b/docs/bingx/spot/public_rest_api.md
@@ -284,21 +284,22 @@ rate limitation by IP in group Number: 1
 
 #### Order Parameters
 
-| Parameter Name | Type    | Description                                                                                                    |
-| -------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
-| symbol         | string  | Trading pair                                                                                                   |
-| tickSize       | float64 | Price step                                                                                                     |
-| stepSize       | float64 | Quantity step                                                                                                  |
-| minQty         | float64 | Version upgrade, this field is deprecated, please ignore this field,the formula is: minQty= minNotional/price  |
-| maxQty         | float64 | Version upgrade, this field is deprecated, please ignore this field,the formula is: maxQty = maxNotional/price |
-| minNotional    | float64 | Minimum transaction amount                                                                                     |
-| maxNotional    | float64 | Maximum transaction amount                                                                                     |
-| status         | int     | 0 offline, 1 online, 5 pre-open, 25 trading suspended                                                          |
-| apiStateBuy    | Boolean | available buy via api                                                                                          |
-| apiStateSell   | Boolean | available sell via api                                                                                         |
-| timeOnline     | long    | online time                                                                                                    |
-| offTime        | long    | offline time                                                                                                   |
-| maintainTime   | long    | trading suspension time                                                                                        |
+| Parameter Name | Type    | Description                                                                                                                                   |
+| -------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| symbol         | string  | Trading pair                                                                                                                                  |
+| tickSize       | float64 | Price step                                                                                                                                    |
+| stepSize       | float64 | Quantity step                                                                                                                                 |
+| minQty         | float64 | Version upgrade, this field is deprecated, please ignore this field,the formula is: minQty= minNotional/price                                 |
+| maxQty         | float64 | Version upgrade, this field is deprecated, please ignore this field,the formula is: maxQty = maxNotional/price                                |
+| minNotional    | float64 | Minimum transaction amount                                                                                                                    |
+| maxNotional    | float64 | Maximum transaction amount                                                                                                                    |
+| status         | int     | 0 offline, 1 online, 5 pre-open, 25 trading suspended                                                                                         |
+| apiStateBuy    | Boolean | available buy via api                                                                                                                         |
+| apiStateSell   | Boolean | available sell via api                                                                                                                        |
+| timeOnline     | long    | online time                                                                                                                                   |
+| offTime        | long    | offline time                                                                                                                                  |
+| maintainTime   | long    | trading suspension time                                                                                                                       |
+| displayName    | string  | The trading pair name displayed on the platform is for display purposes only. Unlike the symbol, which is primarily used for order placement. |
 
 #### Errors
 


### PR DESCRIPTION
## PR Summary

- **USDT-M Perp Futures, Coin-M Perp Futures, and Spot Trading Symbols:**
  - Added a new `displayName` field to the following interfaces:
    - USDT-M Perp Futures symbols
    - Coin-M Perp Futures contract information
    - Spot trading symbols
  - The `displayName` field provides the trading pair name as displayed on the platform, distinct from the symbol used for order placement.
- **Spot Private REST API:**
  - Updated the endpoint documentation for querying sub-account assets:
    - Changed the section title from "Query sub-account spot assets" to "Query sub-account Fund Account".
    - Updated description to clarify that the API checks the balance of the Fund Account for each currency of the sub-account.
- **Spot Public REST API:**
  - Updated the order parameters table to include the new `displayName` field, with a description explaining its purpose.

## Twitter/X Update

🚀 API Update: Added `displayName` to Spot & Perp trading symbols for clearer pair names! Also improved sub-account asset docs. More clarity, less confusion! 🔍📈 #Crypto #API #BingX