### PR TITLE
Binance Options API Documentation Update

### DIFF
--- a/docs/binance/usdm/public_rest_api.md
+++ b/docs/binance/usdm/public_rest_api.md
@@ -2219,12 +2219,14 @@ GET `/futures/data/openInterestHist`
     "symbol": "BTCUSDT",
     "sumOpenInterest": "20403.63700000", // total open interest
     "sumOpenInterestValue": "150570784.07809979", // total open interest value
+    "CMCCirculatingSupply": "165880.538", // circulating supply provided by CMC
     "timestamp": "1583127900000"
   },
   {
     "symbol": "BTCUSDT",
     "sumOpenInterest": "20401.36700000",
     "sumOpenInterestValue": "149940752.14464448",
+    "CMCCirculatingSupply": "165900.14853",
     "timestamp": "1583128200000"
   }
 ]


### PR DESCRIPTION
## PR Summary

- Updated the Binance USDⓈ-M Futures Public REST API documentation.
- Enhanced the response example for the `/futures/data/openInterestHist` endpoint.
- Added a new field, `CMCCirculatingSupply`, to the response example, representing the circulating supply provided by CoinMarketCap (CMC).
- Improved clarity regarding the data returned by this endpoint.

## Twitter/X Update

🚀 Binance USDⓈ-M Futures API docs update! The `/futures/data/openInterestHist` endpoint now includes `CMCCirculatingSupply` in response examples, showing CMC-provided circulating supply data. More transparency for traders! 📊🔍 #BinanceAPI #CryptoDev