### PR TITLE
OKX API Documentation Update

### DIFF
--- a/docs/okx/public_market_data_rest_api.md
+++ b/docs/okx/public_market_data_rest_api.md
@@ -259,7 +259,7 @@ Retrieve funding rate.
 | impactValue     | String   | Depth weighted amount (in the unit of quote currency)                                                                                                                                                                           |
 | settState       | String   | Settlement state of funding rate<br><code>processing</code><br><code>settled</code>                                                                                                                                             |
 | settFundingRate | String   | If settState = <code>processing</code>, it is the funding rate that is being used for current settlement cycle.<br>If settState = <code>settled</code>, it is the funding rate that is being used for previous settlement cycle |
-| premium         | String   | Premium index<br>formula: [(Best bid + Best ask) / 2 – Index price] / Index price                                                                                                                                               |
+| premium         | String   | Premium index<br>formula: [Max (0, Impact bid price – Index price) – Max (0, Index price – Impact ask price)] / Index price                                                                                                     |
 | ts              | String   | Data return time, Unix timestamp format in milliseconds, e.g. <code>1597026383085</code>                                                                                                                                        |
 
 For some altcoins perpetual swaps with significant fluctuations in funding
@@ -273,7 +273,7 @@ to determine the funding fee interval of a contract.
 
 ### Get funding rate history
 
-Retrieve funding rate history. This endpoint can return up to 400 records.
+Retrieve funding rate history. This endpoint can return data up to three months.
 
 #### Rate Limit: 10 requests per 2 seconds
 
@@ -290,7 +290,7 @@ Retrieve funding rate history. This endpoint can return up to 400 records.
 | instId    | String | Yes      | Instrument ID, e.g. <code>BTC-USD-SWAP</code><br>only applicable to <code>SWAP</code>           |
 | before    | String | No       | Pagination of data to return records newer than the requested <code>fundingTime</code>          |
 | after     | String | No       | Pagination of data to return records earlier than the requested <code>fundingTime</code>        |
-| limit     | String | No       | Number of results per request. The maximum is <code>100</code>; The default is <code>100</code> |
+| limit     | String | No       | Number of results per request. The maximum is <code>400</code>; The default is <code>400</code> |
 
 #### Response Parameters
 
@@ -759,11 +759,11 @@ It will return premium data in the past 6 months.
 
 #### Response Parameters
 
-| **Parameter** | **Type** | **Description**                                                                              |
-| ------------- | -------- | -------------------------------------------------------------------------------------------- |
-| instId        | String   | Instrument ID, e.g. <code>BTC-USDT-SWAP</code>                                               |
-| premium       | String   | Premium index<br>formula: [(Best bid + Best ask) / 2 – Index price] / Index price            |
-| ts            | String   | Data generation time, Unix timestamp format in milliseconds, e.g. <code>1597026383085</code> |
+| **Parameter** | **Type** | **Description**                                                                                                             |
+| ------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| instId        | String   | Instrument ID, e.g. <code>BTC-USDT-SWAP</code>                                                                              |
+| premium       | String   | Premium index<br>formula: [Max (0, Impact bid price – Index price) – Max (0, Index price – Impact ask price)] / Index price |
+| ts            | String   | Data generation time, Unix timestamp format in milliseconds, e.g. <code>1597026383085</code>                                |
 
 ---
 

--- a/docs/okx/public_market_data_websocket_api.md
+++ b/docs/okx/public_market_data_websocket_api.md
@@ -448,7 +448,7 @@ Retrieve funding rate. Data will be pushed in 30s to 90s.
 | &gt; impactValue     | String           | Depth weighted amount (in the unit of quote currency)                                                                                                                                                                           |
 | &gt; settState       | String           | Settlement state of funding rate<br><code>processing</code><br><code>settled</code>                                                                                                                                             |
 | &gt; settFundingRate | String           | If settState = <code>processing</code>, it is the funding rate that is being used for current settlement cycle.<br>If settState = <code>settled</code>, it is the funding rate that is being used for previous settlement cycle |
-| &gt; premium         | String           | Premium index<br>formula: [(Best bid + Best ask) / 2 – Index price] / Index price                                                                                                                                               |
+| &gt; premium         | String           | Premium index<br>formula: [Max (0, Impact bid price – Index price) – Max (0, Index price – Impact ask price)] / Index price                                                                                                     |
 | &gt; ts              | String           | Data return time, Unix timestamp format in milliseconds, e.g. <code>1597026383085</code>                                                                                                                                        |
 
 For some altcoins perpetual swaps with significant fluctuations in funding


### PR DESCRIPTION
## PR Summary

- **REST API Documentation Updates:**
  - Updated the formula for the `premium` parameter in funding rate and premium index endpoints to:  
    `[Max (0, Impact bid price – Index price) – Max (0, Index price – Impact ask price)] / Index price`
  - Clarified the "Get funding rate history" endpoint:
    - The endpoint now returns data up to three months (previously described as up to 400 records).
    - Increased the `limit` parameter maximum and default values from 100 to 400.

- **WebSocket API Documentation Updates:**
  - Updated the formula for the `premium` parameter in the funding rate channel to match the new calculation used in the REST API.

## Twitter/X Update

🔄 OKX API docs update!  
- New premium index formula for funding rate & premium endpoints  
- Funding rate history: now up to 3 months & 400 records per request  
Stay up to date with the latest API changes! 🚀 #crypto #API #OKX