### PR TITLE
DigiFinex API Documentation Update

### DIFF
--- a/docs/digifinex/websocket_api.md
+++ b/docs/digifinex/websocket_api.md
@@ -4,7 +4,7 @@
 >
 > **Source**: https://raw.githubusercontent.com/DigiFinex/api/master/Websocket_API_en.md
 >
-> **Last Updated**: 2025-07-05T00:05:30.519Z
+> **Last Updated**: 2025-07-07T00:06:17.484Z
 
 ---
 


### PR DESCRIPTION
- Updated the "Last Updated" timestamp in the DigiFinex WebSocket API documentation to reflect the latest revision date (2025-07-07).
- No changes were made to API endpoints, parameters, or content—only the metadata indicating the documentation's last update was modified.