### PR TITLE
Gate.io API Documentation Update

### DIFF
--- a/docs/gateio/delivery/private_rest_trading_api.md
+++ b/docs/gateio/delivery/private_rest_trading_api.md
@@ -1,4 +1,4 @@
-# [#](#gate-api-v4-v4-100-3) Gate API v4 v4.100.3
+# [#](#gate-api-v4-v4-101-1) Gate API v4 v4.101.1
 
 Scroll down for code samples, example requests and responses. Select a language
 for code samples from the tabs above or the mobile navigation menu.
@@ -838,7 +838,7 @@ account, you will be able to make use of these endpoints.
 
 Related endpoint can be found in the Unified Account API doc. After enabling the
 Unified Account, you can proceed to call them. For more detailed information,
-please refer to [here](https://www.gate.io/unified-trading-account)
+please refer to [here](https://www.gate.com/unified-trading-account)
 
 ### [#](#api-integration-process) API Integration Process
 

--- a/docs/gateio/delivery/websocket_api.md
+++ b/docs/gateio/delivery/websocket_api.md
@@ -2618,4 +2618,4 @@ The above command returns JSON structured like this:
 
   `unsubscribe`
 
-Last Updated: 5/19/2025, 3:42:48 AM
+Last Updated: 7/8/2025, 1:29:05 PM

--- a/docs/gateio/futures/private_rest_trading_api.md
+++ b/docs/gateio/futures/private_rest_trading_api.md
@@ -1,4 +1,4 @@
-# [#](#gate-api-v4-v4-100-3) Gate API v4 v4.100.3
+# [#](#gate-api-v4-v4-101-1) Gate API v4 v4.101.1
 
 Scroll down for code samples, example requests and responses. Select a language
 for code samples from the tabs above or the mobile navigation menu.
@@ -838,7 +838,7 @@ account, you will be able to make use of these endpoints.
 
 Related endpoint can be found in the Unified Account API doc. After enabling the
 Unified Account, you can proceed to call them. For more detailed information,
-please refer to [here](https://www.gate.io/unified-trading-account)
+please refer to [here](https://www.gate.com/unified-trading-account)
 
 ### [#](#api-integration-process) API Integration Process
 
@@ -2792,7 +2792,7 @@ _Get index constituents_
       ]
     },
     {
-      "exchange": "Gate.io",
+      "exchange": "Gate.com",
       "symbols": [
         "BTC_USDT"
       ]
@@ -5399,15 +5399,7 @@ To perform this operation, you must be authenticated by API key and secret
 
 _Countdown cancel orders_
 
-When the timeout set by the user is reached, if there is no cancel or set a new
-countdown, the related pending orders will be automatically cancelled. This
-endpoint can be called repeatedly to set a new countdown or cancel the
-countdown. For example, call this endpoint at 30s intervals, each
-countdown`timeout` is set to 30s. If this endpoint is not called again within 30
-seconds, all pending orders on the specified `market` will be automatically
-cancelled, if no `market` is specified, all market pending orders will be
-cancelled. If the `timeout` is set to 0 within 30 seconds, the countdown timer
-will expire and the cacnel function will be cancelled.
+合约订单心跳检测，在到达用户设置的`timeout`时间时如果没有取消既有倒计时或设置新的倒计时将会自动取消相关的`合约挂单`。 该接口可重复调用，以便设置新的倒计时或取消倒计时。 用法示例： 以30s的间隔重复此接口，每次倒计时`timeout`设置为30(秒)。 如果在30秒内未再次调用此接口，则您指定`market`上的所有挂单都会被自动撤销。 如果在30秒内以将`timeout`设置为0，则倒数计时器将终止，自动撤单功能取消。
 
 > Body parameter
 
@@ -5420,16 +5412,16 @@ will expire and the cacnel function will be cancelled.
 
 ### Parameters
 
-| Name       | In   | Type           | Required | Description                |
-| ---------- | ---- | -------------- | -------- | -------------------------- |
-| body       | body | object         | true     | none                       |
-| » timeout  | body | integer(int32) | true     | Countdown time, in seconds |
-| » contract | body | string         | false    | Futures contract           |
-| settle     | path | string         | true     | Settle currency            |
+| Name       | In   | Type           | Required | Description               |
+| ---------- | ---- | -------------- | -------- | ------------------------- |
+| body       | body | object         | true     | none                      |
+| » timeout  | body | integer(int32) | true     | Countdown time in seconds |
+| » contract | body | string         | false    | Futures contract          |
+| settle     | path | string         | true     | Settle currency           |
 
 #### [#](#detailed-descriptions-29) Detailed descriptions
 
-**» timeout**: Countdown time, in seconds At least 5 seconds, 0 means cancel the
+**» timeout**: Countdown time in seconds At least 5 seconds, 0 means cancel
 countdown
 
 #### [#](#enumerated-values-74) Enumerated Values

--- a/docs/gateio/futures/websocket_api.md
+++ b/docs/gateio/futures/websocket_api.md
@@ -5330,7 +5330,7 @@ contains the following fields:
 
 Note that the type of `payload.req_param` is channel specific, Take
 `futures.order_place` for example, `payload.req_param` same as apiv4
-[/futures/{settle}/orders (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#create-a-futures-order).
+[/futures/{settle}/orders (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#create-a-futures-order).
 You can place a limit order for BTC_USDT with example.
 
 ### [#](#websocket-api-server-response) Websocket API Server Response
@@ -5943,12 +5943,12 @@ Request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                                                                                     |
-| --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,                                                                     |
+| Field                             | Type     | Required | Description                                                                                                                                                                      |
+| --------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,                                                                      |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | Api order model's json byte data, use api order model; api order model detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#create-a-futures-order) |
-| `req_header`                      | `object` | No       | Apiv4 custom header                                                                                                                                                             |
+| `req_param`                       | `object` | Yes      | Api order model's json byte data, use api order model; api order model detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#create-a-futures-order) |
+| `req_header`                      | `object` | No       | Apiv4 custom header                                                                                                                                                              |
 
 `req_param` JSON byte data of the API order model:
 
@@ -6260,12 +6260,12 @@ Request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                                                                                                         |
-| --------------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,                                                                                         |
+| Field                             | Type     | Required | Description                                                                                                                                                                                          |
+| --------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,                                                                                          |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | Api order model's json byte data, an array with api order model; api order model detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#create-a-batch-of-futures-orders) |
-| `req_header`                      | `object` | No       | Apiv4 custom header                                                                                                                                                                                 |
+| `req_param`                       | `object` | Yes      | Api order model's json byte data, an array with api order model; api order model detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#create-a-batch-of-futures-orders) |
+| `req_header`                      | `object` | No       | Apiv4 custom header                                                                                                                                                                                  |
 
 `req_param` The JSON byte data for the API order model can refer to a single
 order placement, or an array of multiple single orders. For details, refer to
@@ -6511,12 +6511,18 @@ Order cancel request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                                 |
-| --------------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,                 |
+| Field                             | Type     | Required | Description                                                                                                                  |
+| --------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,                  |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | Api cancel order, detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-a-single-order-2) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                         |
+| `req_param`                       | `object` | Yes      | Api cancel order, detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-a-single-order-2) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                          |
+
+`req_param` API order model JSON data:
+
+| Field      | Type     | Required | Description                                                                                                 |
+| ---------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `order_id` | `string` | Yes      | Order ID returned when the order was successfully created, or user specified custom ID (i.e. `text` field). |
 
 `req_header` Custom header data:
 
@@ -6590,7 +6596,7 @@ Result format:
 | »`x_gat_ratelimit_reset_timestamp`  | Integer | If the current rate limit has been exceeded, this indicates the timestamp (in milliseconds) of the next available time window when access can be resumed. If the limit has not been exceeded, the response returns the current server time (in milliseconds) |
 | »`conn_id`                          | String  | Connection ID established with the client (remains consistent for the same connection)                                                                                                                                                                       |
 | `data`                              | Object  | Response data of the request                                                                                                                                                                                                                                 |
-| »`result`                           | Object  | Single order cancel response, detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-a-single-order-2)                                                                                                                      |
+| »`result`                           | Object  | Single order cancel response, detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-a-single-order-2)                                                                                                                     |
 | »`errs`                             | Object  | It is only available when the request fails                                                                                                                                                                                                                  |
 | »»`label`                           | String  | Denotes error type in string format                                                                                                                                                                                                                          |
 | »»`message`                         | String  | Detailed error message                                                                                                                                                                                                                                       |
@@ -6754,24 +6760,24 @@ Order cancel notification example
 
 Result format:
 
-| Field            | Type    | Description                                                                                                                          |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `request_id`     | String  | Unique identifier of the message                                                                                                     |
-| `header`         | Map     | response meta info                                                                                                                   |
-| »`response_time` | String  | response send time in mill                                                                                                           |
-| »`channel`       | String  | request channel                                                                                                                      |
-| »`event`         | String  | request event                                                                                                                        |
-| »`client_id`     | String  | Unique client id                                                                                                                     |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                        |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                            |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                               |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                          |
-| »`trace_id`      | String  | TraceId for executing order operation                                                                                                |
-| `data`           | Object  | Response data of the request                                                                                                         |
-| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-a-batch-of-orders-with-an-id-list-2) |
-| »`errs`          | Object  | It is only available when the request fails                                                                                          |
-| »»`label`        | String  | denotes error type in string format                                                                                                  |
-| »»`message`      | String  | detailed error message                                                                                                               |
+| Field            | Type    | Description                                                                                                                           |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                                                      |
+| `header`         | Map     | response meta info                                                                                                                    |
+| »`response_time` | String  | response send time in mill                                                                                                            |
+| »`channel`       | String  | request channel                                                                                                                       |
+| »`event`         | String  | request event                                                                                                                         |
+| »`client_id`     | String  | Unique client id                                                                                                                      |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                         |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                             |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                                |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                           |
+| »`trace_id`      | String  | TraceId for executing order operation                                                                                                 |
+| `data`           | Object  | Response data of the request                                                                                                          |
+| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-a-batch-of-orders-with-an-id-list-2) |
+| »`errs`          | Object  | It is only available when the request fails                                                                                           |
+| »»`label`        | String  | denotes error type in string format                                                                                                   |
+| »»`message`      | String  | detailed error message                                                                                                                |
 
 ## [#](#cancel-all-open-orders-matched) Cancel all open orders matched
 
@@ -6891,12 +6897,12 @@ Client request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                      |
-| --------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,      |
+| Field                             | Type     | Required | Description                                                                                                       |
+| --------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,       |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | Detail to.[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-all-open-orders-matched) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                              |
+| `req_param`                       | `object` | Yes      | Detail to.[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-all-open-orders-matched) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                               |
 
 `req_header` Custom header data:
 
@@ -6972,7 +6978,7 @@ Result format:
 | »`x_gat_ratelimit_reset_timestamp`  | Integer | If the current rate limit has been exceeded, this indicates the timestamp (in milliseconds) of the next available time window when access can be resumed. If the limit has not been exceeded, the response returns the current server time (in milliseconds) |
 | »`conn_id`                          | String  | Connection ID established with the client (remains consistent for the same connection)                                                                                                                                                                       |
 | `data`                              | Object  | Response data of the request                                                                                                                                                                                                                                 |
-| »`result`                           | Object  | Response detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-all-open-orders-matched)                                                                                                                                    |
+| »`result`                           | Object  | Response detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-all-open-orders-matched)                                                                                                                                   |
 | »`errs`                             | Object  | It is only available when the request fails                                                                                                                                                                                                                  |
 | »»`label`                           | String  | Denotes error type in string format                                                                                                                                                                                                                          |
 | »»`message`                         | String  | Detailed error message                                                                                                                                                                                                                                       |
@@ -7095,12 +7101,12 @@ Client request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                         |
-| --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,         |
+| Field                             | Type     | Required | Description                                                                                                          |
+| --------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,          |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | Api amend order, detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#amend-an-order-2) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                 |
+| `req_param`                       | `object` | Yes      | Api amend order, detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#amend-an-order-2) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                  |
 
 `req_header` Custom header data:
 
@@ -7172,7 +7178,7 @@ Result format:
 | »`x_gat_ratelimit_reset_timestamp`  | Integer | If the current rate limit has been exceeded, this indicates the timestamp (in milliseconds) of the next available time window when access can be resumed. If the limit has not been exceeded, the response returns the current server time (in milliseconds) |
 | »`conn_id`                          | String  | Connection ID established with the client (remains consistent for the same connection)                                                                                                                                                                       |
 | `data`                              | Object  | Response data of the request                                                                                                                                                                                                                                 |
-| »`result`                           | Object  | Response detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#amend-an-order-2)                                                                                                                                                  |
+| »`result`                           | Object  | Response detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#amend-an-order-2)                                                                                                                                                 |
 | »`errs`                             | Object  | It is only available when the request fails                                                                                                                                                                                                                  |
 | »»`label`                           | String  | Denotes error type in string format                                                                                                                                                                                                                          |
 | »»`message`                         | String  | Detailed error message                                                                                                                                                                                                                                       |
@@ -7296,11 +7302,11 @@ Client request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                           |
-| --------------------------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,           |
+| Field                             | Type     | Required | Description                                                                                                            |
+| --------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to,            |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | Api list order, detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#list-futures-orders) |
+| `req_param`                       | `object` | Yes      | Api list order, detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#list-futures-orders) |
 
 ### [#](#order-list-notification) Order List Notification
 
@@ -7351,24 +7357,24 @@ Order list notification example
 
 Result format:
 
-| Field            | Type    | Description                                                                                                    |
-| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
-| `request_id`     | String  | Unique identifier of the message                                                                               |
-| `header`         | Map     | Response meta info                                                                                             |
-| »`response_time` | String  | Response send time in mill                                                                                     |
-| »`channel`       | String  | Request channel                                                                                                |
-| »`event`         | String  | Request event                                                                                                  |
-| »`client_id`     | String  | Unique client id                                                                                               |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                  |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                      |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                         |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                    |
-| »`trace_id`      | String  | TraceId for executing order operation                                                                          |
-| `data`           | Object  | Signature time in seconds                                                                                      |
-| »`result`        | Object  | Response detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#list-futures-orders) |
-| »`errs`          | Object  | It is only available when the request fails                                                                    |
-| »»`label`        | String  | Denotes error type in string format                                                                            |
-| »»`message`      | String  | Detailed error message                                                                                         |
+| Field            | Type    | Description                                                                                                     |
+| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                                |
+| `header`         | Map     | Response meta info                                                                                              |
+| »`response_time` | String  | Response send time in mill                                                                                      |
+| »`channel`       | String  | Request channel                                                                                                 |
+| »`event`         | String  | Request event                                                                                                   |
+| »`client_id`     | String  | Unique client id                                                                                                |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                   |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                       |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                          |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                     |
+| »`trace_id`      | String  | TraceId for executing order operation                                                                           |
+| `data`           | Object  | Signature time in seconds                                                                                       |
+| »`result`        | Object  | Response detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#list-futures-orders) |
+| »`errs`          | Object  | It is only available when the request fails                                                                     |
+| »»`label`        | String  | Denotes error type in string format                                                                             |
+| »»`message`      | String  | Detailed error message                                                                                          |
 
 ## [#](#order-status) Order Status
 
@@ -7491,7 +7497,7 @@ Payload format:
 | --------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
 | `req_id`                          | `string` | Yes      | Request id which will be sent back by the server to help you identify which request the server responds to, |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | Detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#get-a-single-order-2)      |
+| `req_param`                       | `object` | Yes      | Detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#get-a-single-order-2)     |
 
 ### [#](#order-cancel-notification) Order Cancel Notification
 
@@ -7537,23 +7543,23 @@ Order cancel notification example
 
 Result format:
 
-| Field            | Type    | Description                                                                                                     |
-| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `request_id`     | String  | Unique identifier of the message                                                                                |
-| `header`         | Map     | Response meta info                                                                                              |
-| »`response_time` | String  | Response send time in mill                                                                                      |
-| »`channel`       | String  | Request channel                                                                                                 |
-| »`event`         | String  | Request event                                                                                                   |
-| »`client_id`     | String  | Unique client id                                                                                                |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                   |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                       |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                          |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                     |
-| »`trace_id`      | String  | TraceId for executing order operation                                                                           |
-| `data`           | Object  | Signature time in seconds                                                                                       |
-| »`result`        | Object  | Response detail to [api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#get-a-single-order-2) |
-| »`errs`          | Object  | It is only available when the request fails                                                                     |
-| »»`label`        | String  | Denotes error type in string format                                                                             |
-| »»`message`      | String  | Detailed error message                                                                                          |
+| Field            | Type    | Description                                                                                                      |
+| ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                                 |
+| `header`         | Map     | Response meta info                                                                                               |
+| »`response_time` | String  | Response send time in mill                                                                                       |
+| »`channel`       | String  | Request channel                                                                                                  |
+| »`event`         | String  | Request event                                                                                                    |
+| »`client_id`     | String  | Unique client id                                                                                                 |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                    |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                        |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                           |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                      |
+| »`trace_id`      | String  | TraceId for executing order operation                                                                            |
+| `data`           | Object  | Signature time in seconds                                                                                        |
+| »`result`        | Object  | Response detail to [api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#get-a-single-order-2) |
+| »`errs`          | Object  | It is only available when the request fails                                                                      |
+| »»`label`        | String  | Denotes error type in string format                                                                              |
+| »»`message`      | String  | Detailed error message                                                                                           |
 
-Last Updated: 7/3/2025, 6:15:49 AM
+Last Updated: 7/8/2025, 1:29:05 PM

--- a/docs/gateio/options/private_rest_trading_api.md
+++ b/docs/gateio/options/private_rest_trading_api.md
@@ -1,4 +1,4 @@
-# [#](#gate-api-v4-v4-100-3) Gate API v4 v4.100.3
+# [#](#gate-api-v4-v4-101-1) Gate API v4 v4.101.1
 
 Scroll down for code samples, example requests and responses. Select a language
 for code samples from the tabs above or the mobile navigation menu.
@@ -838,7 +838,7 @@ account, you will be able to make use of these endpoints.
 
 Related endpoint can be found in the Unified Account API doc. After enabling the
 Unified Account, you can proceed to call them. For more detailed information,
-please refer to [here](https://www.gate.io/unified-trading-account)
+please refer to [here](https://www.gate.com/unified-trading-account)
 
 ### [#](#api-integration-process) API Integration Process
 
@@ -3976,17 +3976,9 @@ To perform this operation, you must be authenticated by API key and secret
 
 _Countdown cancel orders_
 
-Option order heartbeat detection, when the `timeout` time set by the user is
-reached, if the existing countdown is not canceled or a new countdown is set,
-the related `option pending order` will be automatically canceled. This
-interface can be called repeatedly to set a new countdown or cancel the
-countdown. Usage example: Repeat this interface at intervals of 30 seconds, with
-each countdown `timeout` set to 30 (seconds). If this interface is not called
-again within 30 seconds, all pending orders on the `underlying` `contract` you
-specified will be automatically cancelled. If `underlying` `contract` is not
-specified, all pending orders of the user will be automatically cancelled If
-`timeout` is set to 0 within 30 seconds, the countdown timer will expire and the
-automatic order cancellation function will be cancelled.
+期权订单心跳检测，在到达用户设置的`timeout`时间时如果没有取消既有倒计时或设置新的倒计时将会自动取消相关的`期权挂单`。 该接口可重复调用，以便设置新的倒计时或取消倒计时。 用法示例： 以30s的间隔重复此接口，每次倒计时`timeout`设置为30(秒)。 如果在30秒内未再次调用此接口，则您指定的`underlying`
+`contract`上的所有挂单都会被自动撤销，若未指定`underlying`
+`contract`则会自动撤销用户的全部挂单 如果在30秒内以将`timeout`设置为0，则倒数计时器将终止，自动撤单功能取消。
 
 > Body parameter
 
@@ -4000,16 +3992,16 @@ automatic order cancellation function will be cancelled.
 
 ### Parameters
 
-| Name         | In   | Type           | Required | Description                |
-| ------------ | ---- | -------------- | -------- | -------------------------- |
-| body         | body | object         | true     | none                       |
-| » timeout    | body | integer(int32) | true     | Countdown time, in seconds |
-| » contract   | body | string         | false    | Options contract name      |
-| » underlying | body | string         | false    | Underlying                 |
+| Name         | In   | Type           | Required | Description               |
+| ------------ | ---- | -------------- | -------- | ------------------------- |
+| body         | body | object         | true     | none                      |
+| » timeout    | body | integer(int32) | true     | Countdown time in seconds |
+| » contract   | body | string         | false    | Options contract name     |
+| » underlying | body | string         | false    | Underlying                |
 
 #### [#](#detailed-descriptions-37) Detailed descriptions
 
-**» timeout**: Countdown time, in seconds At least 5 seconds, 0 means cancel the
+**» timeout**: Countdown time in seconds At least 5 seconds, 0 means cancel
 countdown
 
 > Example responses

--- a/docs/gateio/options/websocket_api.md
+++ b/docs/gateio/options/websocket_api.md
@@ -2094,4 +2094,4 @@ Result format:
 | »`time_ms`      | Integer | Update unix timestamp in milliseconds |
 | »`user`         | String  | User id                               |
 
-Last Updated: 7/3/2025, 6:15:49 AM
+Last Updated: 7/8/2025, 1:29:05 PM

--- a/docs/gateio/spot/private_rest_account_api.md
+++ b/docs/gateio/spot/private_rest_account_api.md
@@ -1,4 +1,4 @@
-# [#](#gate-api-v4-v4-100-3) Gate API v4 v4.100.3
+# [#](#gate-api-v4-v4-101-1) Gate API v4 v4.101.1
 
 Scroll down for code samples, example requests and responses. Select a language
 for code samples from the tabs above or the mobile navigation menu.
@@ -838,7 +838,7 @@ account, you will be able to make use of these endpoints.
 
 Related endpoint can be found in the Unified Account API doc. After enabling the
 Unified Account, you can proceed to call them. For more detailed information,
-please refer to [here](https://www.gate.io/unified-trading-account)
+please refer to [here](https://www.gate.com/unified-trading-account)
 
 ### [#](#api-integration-process) API Integration Process
 
@@ -2392,7 +2392,7 @@ Record time range cannot exceed 30 days
 | ----------------- | ----- | -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | currency          | query | string         | false    | Filter by currency. Return all currency records if not specified                                                                                                            |
 | withdraw_id       | query | string         | false    | The withdrawal record id starts with w, such as: w1879219868. When withdraw_id is not empty, the value querys this withdrawal record and no longer querys according to time |
-| asset_class       | query | string         | false    | The currency type of withdrawal record is empty by default. It supports users to query the withdrawal records in the main and innovation areas on demand.                   |
+| asset_class       | query | string         | false    | 提现记录币种类型，默认为空。即支持用户按需查询主区和创新区的提现记录。                                                                                                      |
 | withdraw_order_id | query | string         | false    | User-defined order number when withdrawing. Default is empty. When not empty, the specified user-defined order number record will be queried                                |
 | from              | query | integer(int64) | false    | Time range beginning, default to 7 days before current time                                                                                                                 |
 | to                | query | integer(int64) | false    | Time range ending, default to current time                                                                                                                                  |
@@ -2401,11 +2401,9 @@ Record time range cannot exceed 30 days
 
 #### [#](#detailed-descriptions-2) Detailed descriptions
 
-**asset_class**: The currency type of withdrawal record is empty by default. It
-supports users to query the withdrawal records in the main and innovation areas
-on demand. Value range: SPOT, PILOT
+**asset_class**: 提现记录币种类型，默认为空。即支持用户按需查询主区和创新区的提现记录。 取值范围：SPOT、PILOT
 
-SPOT: Main Zone PILOT: Innovation Zone
+SPOT ： 主区 PILOT： 创新区
 
 > Example responses
 

--- a/docs/gateio/spot/private_rest_trading_api.md
+++ b/docs/gateio/spot/private_rest_trading_api.md
@@ -1,4 +1,4 @@
-# [#](#gate-api-v4-v4-100-3) Gate API v4 v4.100.3
+# [#](#gate-api-v4-v4-101-1) Gate API v4 v4.101.1
 
 Scroll down for code samples, example requests and responses. Select a language
 for code samples from the tabs above or the mobile navigation menu.
@@ -838,7 +838,7 @@ account, you will be able to make use of these endpoints.
 
 Related endpoint can be found in the Unified Account API doc. After enabling the
 Unified Account, you can proceed to call them. For more detailed information,
-please refer to [here](https://www.gate.io/unified-trading-account)
+please refer to [here](https://www.gate.com/unified-trading-account)
 
 ### [#](#api-integration-process) API Integration Process
 
@@ -2212,7 +2212,7 @@ _List all currency pairs supported_
     "sell_start": 1516378650,
     "buy_start": 1516378650,
     "delisting_time": 0,
-    "trade_url": "https://www.gate.io/trade/ETH_USDT"
+    "trade_url": "https://www.gate.com/trade/ETH_USDT"
   }
 ]
 ```
@@ -2302,7 +2302,7 @@ _Get details of a specifc currency pair_
   "sell_start": 1516378650,
   "buy_start": 1516378650,
   "delisting_time": 0,
-  "trade_url": "https://www.gate.io/trade/ETH_USDT"
+  "trade_url": "https://www.gate.com/trade/ETH_USDT"
 }
 ```
 
@@ -4299,16 +4299,16 @@ account
 | -------------- | ------ | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | currency_pair  | query  | string | false    | Currency pair                                                                                                                                    |
 | side           | query  | string | false    | All bids or asks. Both included if not specified                                                                                                 |
-| account        | query  | string | false    | Specify Account Type                                                                                                                             |
+| account        | query  | string | false    | 指定账户类型                                                                                                                                     |
 | action_mode    | query  | string | false    | Processing Mode                                                                                                                                  |
 | x-gate-exptime | header | string | false    | Specify the expiration time (milliseconds); if the GATE receives the request time greater than the expiration time, the request will be rejected |
 
 #### [#](#detailed-descriptions-14) Detailed descriptions
 
-**account**: Specify Account Type
+**account**: 指定账户类型
 
-- Classic Account: If not specified, all include
-- Unified Account: Specify `unified`
+- 经典账户：不指定则全部包含
+- 统一账户：指定`unified`
 
 **action_mode**: Processing Mode
 
@@ -4793,24 +4793,38 @@ To perform this operation, you must be authenticated by API key and secret
 
 _Amend an order_
 
-By default modify orders for spot, unified account and leverage account.
+Modify orders in spot, unified account and isolated margin account by default.
 
-At present, both the request body and query support currency_pair and account
-parameters, but the request body has higher priority
+Currently both request body and query support currency_pair and account
+parameters, but request body has higher priority.
 
-currency_pair must be filled in the request body or query
+currency_pair must be filled in one of the request body or query parameters.
 
-Currently, it supports modifying the price or quantity (choose one of two), and
-also supports modifying the price and quantity at the same time
+About rate limit: Order modification and order creation share the same rate
+limit rules.
 
-About speed limit: Modify orders and create orders to share speed limit rules
+About matching priority: Only reducing the quantity does not affect the matching
+priority. Modifying the price or increasing the quantity will adjust the
+priority to the end of the new price level.
 
-About matching priority: Only modifying the quantity will become smaller and
-will not affect the priority of matching. If the price is modified or the
-quantity is modified, the priority will be adjusted to the end of the new price
+Note: Modifying the quantity to be less than the filled quantity will trigger a
+cancellation operation.Modify orders in spot, unified account and isolated
+margin account by default.
 
-Precautions: Modification quantity is less than the transaction quantity will
-trigger the order cancellation operation
+Currently both request body and query support currency_pair and account
+parameters, but request body has higher priority.
+
+currency_pair must be filled in one of the request body or query parameters.
+
+About rate limit: Order modification and order creation share the same rate
+limit rules.
+
+About matching priority: Only reducing the quantity does not affect the matching
+priority. Modifying the price or increasing the quantity will adjust the
+priority to the end of the new price level.
+
+Note: Modifying the quantity to be less than the filled quantity will trigger a
+cancellation operation.
 
 > Body parameter
 
@@ -4833,8 +4847,8 @@ trigger the order cancellation operation
 | body            | body   | object | true     | none                                                                                                                                             |
 | » currency_pair | body   | string | false    | Currency pair                                                                                                                                    |
 | » account       | body   | string | false    | Specify query account.                                                                                                                           |
-| » amount        | body   | string | false    | New order amount. `amount` and `price` must specify one of them                                                                                  |
-| » price         | body   | string | false    | New order price. `amount` and `Price` must specify one of them"                                                                                  |
+| » amount        | body   | string | false    | 交易数量，`amount`和`price`必须指定其中一个                                                                                                      |
+| » price         | body   | string | false    | 交易价，`amount`和`price`必须指定其中一个                                                                                                        |
 | » amend_text    | body   | string | false    | Custom info during amending order                                                                                                                |
 | » action_mode   | body   | string | false    | Processing Mode:                                                                                                                                 |
 
@@ -5415,15 +5429,17 @@ This operation does not require authentication
 
 _Countdown cancel orders_
 
-When the timeout set by the user is reached, if there is no cancel or set a new
-countdown, the related pending orders will be automatically cancelled. This
-endpoint can be called repeatedly to set a new countdown or cancel the
-countdown. For example, call this endpoint at 30s intervals, each
-countdown`timeout` is set to 30s. If this endpoint is not called again within 30
-seconds, all pending orders on the specified `market` will be automatically
-cancelled, if no `market` is specified, all market pending orders will be
+Spot order heartbeat detection. If there is no "cancel existing countdown" or
+"set new countdown" when the user-set `timeout` time is reached, the related
+`spot pending orders` will be automatically cancelled. This interface can be
+called repeatedly to set a new countdown or cancel the countdown. Usage example:
+Repeat this interface at 30s intervals, setting the countdown `timeout` to
+`30 (seconds)` each time. If this interface is not called again within 30
+seconds, all pending orders on the `market` you specified will be automatically
+cancelled. If no `market` is specified, all market pending orders will be
 cancelled. If the `timeout` is set to 0 within 30 seconds, the countdown timer
-will expire and the cacnel function will be cancelled.
+will be terminated and the automatic order cancellation function will be
+cancelled.
 
 > Body parameter
 
@@ -5436,15 +5452,15 @@ will expire and the cacnel function will be cancelled.
 
 ### Parameters
 
-| Name            | In   | Type           | Required | Description                |
-| --------------- | ---- | -------------- | -------- | -------------------------- |
-| body            | body | object         | true     | none                       |
-| » timeout       | body | integer(int32) | true     | Countdown time, in seconds |
-| » currency_pair | body | string         | false    | Currency pair              |
+| Name            | In   | Type           | Required | Description               |
+| --------------- | ---- | -------------- | -------- | ------------------------- |
+| body            | body | object         | true     | none                      |
+| » timeout       | body | integer(int32) | true     | Countdown time in seconds |
+| » currency_pair | body | string         | false    | Currency pair             |
 
 #### [#](#detailed-descriptions-18) Detailed descriptions
 
-**» timeout**: Countdown time, in seconds At least 5 seconds, 0 means cancel the
+**» timeout**: Countdown time in seconds At least 5 seconds, 0 means cancel
 countdown
 
 > Example responses
@@ -5485,15 +5501,14 @@ To perform this operation, you must be authenticated by API key and secret
 
 _Batch modification of orders_
 
-By default modify orders for spot, unified account and leverage account.
-Currently, only the price or quantity modification (choose one of two) Modify
-unfinished orders, up to 5 orders can be modified in batches at a time. The
-request parameters should be passed in array format. When the order modification
-fails during batch modification, the modification of the order will continue to
-be executed. After execution, the failure information of the corresponding order
-will be carried The order of calling the batch modification order is consistent
-with the order list The order of return content of batch modification orders is
-consistent with the order list
+Modify orders in spot, unified account and isolated margin account by default.
+Modify uncompleted orders, up to 5 orders can be modified at a time. Request
+parameters should be passed in array format. If there are order modification
+failures during the batch modification process, the modification of the next
+order will continue to be executed, and the execution will return with the
+corresponding order failure information. The call order of batch modification
+orders is consistent with the order list order. The return content order of
+batch modification orders is consistent with the order list order.
 
 > Body parameter
 

--- a/docs/gateio/spot/websocket_api.md
+++ b/docs/gateio/spot/websocket_api.md
@@ -3780,9 +3780,9 @@ contains the following fields:
 
 Note that the type of `payload.req_param` is channel specific, Take
 `spot.order_place` for example, `payload.req_param` same as apiv4
-[/spot/orders (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#create-an-order)
+[/spot/orders (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#create-an-order)
 or
-[/spot/batch_orders (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#create-a-batch-of-orders).
+[/spot/batch_orders (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#create-a-batch-of-orders).
 You can place a limit order for GT_USDT with example.
 
 ### [#](#websocket-api-server-response) Websocket API Server Response
@@ -4439,12 +4439,12 @@ Request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                                                                                                |
-| --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,                                                                                |
+| Field                             | Type     | Required | Description                                                                                                                                                                                 |
+| --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,                                                                                 |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | api order model's json byte data, could be an array with api order model; api order model detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#create-an-order) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                                                                                        |
+| `req_param`                       | `object` | Yes      | api order model's json byte data, could be an array with api order model; api order model detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#create-an-order) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                                                                                         |
 
 `req_param` JSON byte data of the API order model:
 
@@ -4921,12 +4921,12 @@ Order cancel request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                              |
-| --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,              |
+| Field                             | Type     | Required | Description                                                                                                               |
+| --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,               |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | api cancel order, detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-a-single-order) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                      |
+| `req_param`                       | `object` | Yes      | api cancel order, detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-a-single-order) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                       |
 
 `req_param` JSON byte data of the API order model:
 
@@ -5001,24 +5001,24 @@ Order cancel notification example
 
 Result format:
 
-| Field            | Type    | Description                                                                                                                          |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `request_id`     | String  | Unique identifier of the message                                                                                                     |
-| `header`         | Map     | response meta info                                                                                                                   |
-| »`response_time` | String  | response send time in mill                                                                                                           |
-| »`channel`       | String  | request channel                                                                                                                      |
-| »`event`         | String  | request event                                                                                                                        |
-| »`client_id`     | String  | Unique client id                                                                                                                     |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                        |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                            |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                               |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                          |
-| »`trace_id`      | String  | TraceId for executing order operation                                                                                                |
-| `data`           | Object  | Response data of the request                                                                                                         |
-| »`result`        | Object  | single order cancel response, detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-a-single-order) |
-| »`errs`          | Object  | It is only available when the request fails                                                                                          |
-| »»`label`        | String  | denotes error type in string format                                                                                                  |
-| »»`message`      | String  | detailed error message                                                                                                               |
+| Field            | Type    | Description                                                                                                                           |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                                                      |
+| `header`         | Map     | response meta info                                                                                                                    |
+| »`response_time` | String  | response send time in mill                                                                                                            |
+| »`channel`       | String  | request channel                                                                                                                       |
+| »`event`         | String  | request event                                                                                                                         |
+| »`client_id`     | String  | Unique client id                                                                                                                      |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                         |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                             |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                                |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                           |
+| »`trace_id`      | String  | TraceId for executing order operation                                                                                                 |
+| `data`           | Object  | Response data of the request                                                                                                          |
+| »`result`        | Object  | single order cancel response, detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-a-single-order) |
+| »`errs`          | Object  | It is only available when the request fails                                                                                           |
+| »»`label`        | String  | denotes error type in string format                                                                                                   |
+| »»`message`      | String  | detailed error message                                                                                                                |
 
 ## [#](#order-cancel-all-with-id-list) Order Cancel All With Id List
 
@@ -5146,12 +5146,12 @@ Client request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                               |
-| --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,               |
+| Field                             | Type     | Required | Description                                                                                                                |
+| --------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,                |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-a-batch-of-orders-with-an-id-list) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                       |
+| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-a-batch-of-orders-with-an-id-list) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                        |
 
 `req_param` JSON byte data of the API order model:
 
@@ -5200,24 +5200,24 @@ Order cancel notification example
 
 Result format:
 
-| Field            | Type    | Description                                                                                                                        |
-| ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `request_id`     | String  | Unique identifier of the message                                                                                                   |
-| `header`         | Map     | response meta info                                                                                                                 |
-| »`response_time` | String  | response send time in mill                                                                                                         |
-| »`channel`       | String  | request channel                                                                                                                    |
-| »`event`         | String  | request event                                                                                                                      |
-| »`client_id`     | String  | Unique client id                                                                                                                   |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                      |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                          |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                             |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                        |
-| »`trace_id`      | String  | TraceId for executing order operation                                                                                              |
-| `data`           | Object  | Response data of the request                                                                                                       |
-| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-a-batch-of-orders-with-an-id-list) |
-| »`errs`          | Object  | It is only available when the request fails                                                                                        |
-| »»`label`        | String  | denotes error type in string format                                                                                                |
-| »»`message`      | String  | detailed error message                                                                                                             |
+| Field            | Type    | Description                                                                                                                         |
+| ---------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                                                    |
+| `header`         | Map     | response meta info                                                                                                                  |
+| »`response_time` | String  | response send time in mill                                                                                                          |
+| »`channel`       | String  | request channel                                                                                                                     |
+| »`event`         | String  | request event                                                                                                                       |
+| »`client_id`     | String  | Unique client id                                                                                                                    |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                       |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                           |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                              |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                         |
+| »`trace_id`      | String  | TraceId for executing order operation                                                                                               |
+| `data`           | Object  | Response data of the request                                                                                                        |
+| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-a-batch-of-orders-with-an-id-list) |
+| »`errs`          | Object  | It is only available when the request fails                                                                                         |
+| »»`label`        | String  | denotes error type in string format                                                                                                 |
+| »»`message`      | String  | detailed error message                                                                                                              |
 
 ## [#](#order-cancel-all-with-specified-currency-pair) Order Cancel All With Specified Currency Pair
 
@@ -5339,12 +5339,12 @@ func main() {
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                                        |
-| --------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,                        |
+| Field                             | Type     | Required | Description                                                                                                                         |
+| --------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,                         |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-all-open-orders-in-specified-currency-pair) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                                |
+| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-all-open-orders-in-specified-currency-pair) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                                                 |
 
 `req_param` JSON byte data of the API order model:
 
@@ -5421,24 +5421,24 @@ Order cancel notification example
 
 Result format:
 
-| Field            | Type    | Description                                                                                                                                 |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `request_id`     | String  | Unique identifier of the message                                                                                                            |
-| `header`         | Map     | response meta info                                                                                                                          |
-| »`response_time` | String  | response send time in mill                                                                                                                  |
-| »`channel`       | String  | request channel                                                                                                                             |
-| »`event`         | String  | request event                                                                                                                               |
-| »`client_id`     | String  | Unique client id                                                                                                                            |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                               |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                                   |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                                      |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                                 |
-| »`trace_id`      | String  | TraceId for executing order operation                                                                                                       |
-| `data`           | Object  | Response data of the request                                                                                                                |
-| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#cancel-all-open-orders-in-specified-currency-pair) |
-| »`errs`          | Object  | It is only available when the request fails                                                                                                 |
-| »»`label`        | String  | denotes error type in string format                                                                                                         |
-| »»`message`      | String  | detailed error message                                                                                                                      |
+| Field            | Type    | Description                                                                                                                                  |
+| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                                                             |
+| `header`         | Map     | response meta info                                                                                                                           |
+| »`response_time` | String  | response send time in mill                                                                                                                   |
+| »`channel`       | String  | request channel                                                                                                                              |
+| »`event`         | String  | request event                                                                                                                                |
+| »`client_id`     | String  | Unique client id                                                                                                                             |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                                                |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                                                    |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                                                       |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                                                  |
+| »`trace_id`      | String  | TraceId for executing order operation                                                                                                        |
+| `data`           | Object  | Response data of the request                                                                                                                 |
+| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#cancel-all-open-orders-in-specified-currency-pair) |
+| »`errs`          | Object  | It is only available when the request fails                                                                                                  |
+| »»`label`        | String  | denotes error type in string format                                                                                                          |
+| »»`message`      | String  | detailed error message                                                                                                                       |
 
 ## [#](#order-amend) Order Amend
 
@@ -5564,12 +5564,12 @@ Client request example
 
 Payload format:
 
-| Field                             | Type     | Required | Description                                                                                                      |
-| --------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,      |
+| Field                             | Type     | Required | Description                                                                                                       |
+| --------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to,       |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | api amend order, detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#amend-an-order) |
-| `req_header`                      | `object` | No       | apiv4 custom header                                                                                              |
+| `req_param`                       | `object` | Yes      | api amend order, detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#amend-an-order) |
+| `req_header`                      | `object` | No       | apiv4 custom header                                                                                               |
 
 `req_param` JSON byte data of the API order model:
 
@@ -5667,7 +5667,7 @@ Result format:
 | »`x_gat_ratelimit_reset_timestamp`  | Integer | If the current rate limit has been exceeded, this indicates the timestamp (in milliseconds) of the next available time window when access can be resumed. If the limit has not been exceeded, the response returns the current server time (in milliseconds) |
 | »`conn_id`                          | String  | Connection ID established with the client (remains consistent for the same connection)                                                                                                                                                                       |
 | `data`                              | Object  | Response data of the request                                                                                                                                                                                                                                 |
-| »`result`                           | Object  | response detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#amend-an-order)                                                                                                                                                     |
+| »`result`                           | Object  | response detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#amend-an-order)                                                                                                                                                    |
 | »`errs`                             | Object  | It is only available when the request fails                                                                                                                                                                                                                  |
 | »»`label`                           | String  | denotes error type in string format                                                                                                                                                                                                                          |
 | »»`message`                         | String  | detailed error message                                                                                                                                                                                                                                       |
@@ -5798,7 +5798,7 @@ Payload format:
 | --------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
 | `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to, |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#get-a-single-order)         |
+| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#get-a-single-order)        |
 
 `req_param` JSON byte data of the API order model:
 
@@ -5870,24 +5870,24 @@ will be updated in one notification.
 
 Result format:
 
-| Field            | Type    | Description                                                                                                  |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
-| `request_id`     | String  | Unique identifier of the message                                                                             |
-| `header`         | Map     | response meta info                                                                                           |
-| »`response_time` | String  | response send time in mill                                                                                   |
-| »`channel`       | String  | request channel                                                                                              |
-| »`event`         | String  | request event                                                                                                |
-| »`client_id`     | String  | Unique client id                                                                                             |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                    |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                       |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                  |
-| »`trace_id`      | String  | TraceId for executing order operation                                                                        |
-| `data`           | Object  | Response data of the request                                                                                 |
-| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#get-a-single-order) |
-| »`errs`          | Object  | It is only available when the request fails                                                                  |
-| »»`label`        | String  | denotes error type in string format                                                                          |
-| »»`message`      | String  | detailed error message                                                                                       |
+| Field            | Type    | Description                                                                                                   |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                              |
+| `header`         | Map     | response meta info                                                                                            |
+| »`response_time` | String  | response send time in mill                                                                                    |
+| »`channel`       | String  | request channel                                                                                               |
+| »`event`         | String  | request event                                                                                                 |
+| »`client_id`     | String  | Unique client id                                                                                              |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                                 |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                                     |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)                        |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                                   |
+| »`trace_id`      | String  | TraceId for executing order operation                                                                         |
+| `data`           | Object  | Response data of the request                                                                                  |
+| »`result`        | Object  | response detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#get-a-single-order) |
+| »`errs`          | Object  | It is only available when the request fails                                                                   |
+| »»`label`        | String  | denotes error type in string format                                                                           |
+| »»`message`      | String  | detailed error message                                                                                        |
 
 ## [#](#list-orders) List orders
 
@@ -6021,7 +6021,7 @@ Payload:
 | --------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
 | `req_id`                          | `string` | Yes      | request id which will be sent back by the server to help you identify which request the server responds to, |
 | it's different from outside's`id` |
-| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#list-orders)                |
+| `req_param`                       | `object` | Yes      | detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#list-orders)               |
 
 `req_param` JSON byte data of the API order model:
 
@@ -6172,23 +6172,23 @@ Responses example
 
 Result format:
 
-| Field            | Type    | Description                                                                                       |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `request_id`     | String  | Unique identifier of the message                                                                  |
-| `header`         | Map     | response meta info                                                                                |
-| »`response_time` | String  | response send time in mill                                                                        |
-| »`channel`       | String  | request channel                                                                                   |
-| »`event`         | String  | request event                                                                                     |
-| »`client_id`     | String  | Unique client id                                                                                  |
-| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                     |
-| »`x_out_time`    | Integer | time to return response (in microseconds)                                                         |
-| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)            |
-| »`conn_trace_id` | String  | TraceId to establish connection with client                                                       |
-| »`trace_id`      | String  | TraceId for executing order operation                                                             |
-| `data`           | Object  | Response data of the request                                                                      |
-| »`result`        | Array   | response detail to[api (opens new window)](https://www.gate.io/docs/developers/apiv4/en/#order-2) |
-| »`errs`          | Object  | It is only available when the request fails                                                       |
-| »»`label`        | String  | denotes error type in string format                                                               |
-| »»`message`      | String  | detailed error message                                                                            |
+| Field            | Type    | Description                                                                                        |
+| ---------------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `request_id`     | String  | Unique identifier of the message                                                                   |
+| `header`         | Map     | response meta info                                                                                 |
+| »`response_time` | String  | response send time in mill                                                                         |
+| »`channel`       | String  | request channel                                                                                    |
+| »`event`         | String  | request event                                                                                      |
+| »`client_id`     | String  | Unique client id                                                                                   |
+| »`x_in_time`     | Integer | time to receive the request (in microseconds)                                                      |
+| »`x_out_time`    | Integer | time to return response (in microseconds)                                                          |
+| »`conn_id`       | String  | Connection ID established with the client (remains consistent for the same connection)             |
+| »`conn_trace_id` | String  | TraceId to establish connection with client                                                        |
+| »`trace_id`      | String  | TraceId for executing order operation                                                              |
+| `data`           | Object  | Response data of the request                                                                       |
+| »`result`        | Array   | response detail to[api (opens new window)](https://www.gate.com/docs/developers/apiv4/en/#order-2) |
+| »`errs`          | Object  | It is only available when the request fails                                                        |
+| »»`label`        | String  | denotes error type in string format                                                                |
+| »»`message`      | String  | detailed error message                                                                             |
 
-Last Updated: 7/3/2025, 6:15:49 AM
+Last Updated: 7/8/2025, 1:29:05 PM

--- a/docs/gateio/unified/private_rest_api.md
+++ b/docs/gateio/unified/private_rest_api.md
@@ -1,4 +1,4 @@
-# [#](#gate-api-v4-v4-100-3) Gate API v4 v4.100.3
+# [#](#gate-api-v4-v4-101-1) Gate API v4 v4.101.1
 
 Scroll down for code samples, example requests and responses. Select a language
 for code samples from the tabs above or the mobile navigation menu.
@@ -838,7 +838,7 @@ account, you will be able to make use of these endpoints.
 
 Related endpoint can be found in the Unified Account API doc. After enabling the
 Unified Account, you can proceed to call them. For more detailed information,
-please refer to [here](https://www.gate.io/unified-trading-account)
+please refer to [here](https://www.gate.com/unified-trading-account)
 
 ### [#](#api-integration-process) API Integration Process
 

--- a/docs/gateio/unified/websocket_api.md
+++ b/docs/gateio/unified/websocket_api.md
@@ -11,7 +11,7 @@ language of the examples with the tabs in the top right.
 
 **Base URLs:**
 
-`wss://ws.gate.io/v4/ws/unified`
+`wss://ws.gate.com/v4/ws/unified`
 
 ## [#](#api-overview) API Overview
 
@@ -122,7 +122,7 @@ layer ping message and receive pong message.**
 ```python
 from websocket import create_connection
 
-ws = create_connection("wss://ws.gate.io/v4/ws/unified")
+ws = create_connection("wss://ws.gate.com/v4/ws/unified")
 ws.send(json.dumps({
     "time": int(time.time()),
     "channel": "unified.ping",
@@ -163,7 +163,7 @@ Authentication required.
 import json
 from websocket import create_connection
 
-ws = create_connection("wss://ws.gate.io/v4/ws/unified")
+ws = create_connection("wss://ws.gate.com/v4/ws/unified")
 req = {
     "time": 1700625194,
     "channel": "unified.assets",
@@ -270,7 +270,7 @@ The above command returns JSON structured like this:
 import json
 from websocket import create_connection
 
-ws = create_connection("wss://ws.gate.io/v4/ws/unified")
+ws = create_connection("wss://ws.gate.com/v4/ws/unified")
 req = {
     "time": 123456,
     "channel": "unified.assets",
@@ -327,12 +327,33 @@ Authentication required.
 import json
 from websocket import create_connection
 
-ws = create_connection("wss://ws.gate.io/v4/ws/unified")
+ws = create_connection("wss://ws.gate.com/v4/ws/unified")
 req = {
     "time": 1716796362,
     "channel": "unified.asset_detail",
     "event": "subscribe",
     "payload": ["BTC","ETH"],
+    "auth": {
+        "method": "api_key",
+        "KEY": "xxxx",
+        "SIGN": "xxxx"
+    }
+}
+ws.send(json.dumps(req))
+print(ws.recv())
+```
+
+```python
+# Subscribe to all currencies
+import json
+from websocket import create_connection
+
+ws = create_connection("wss://ws.gate.com/v4/ws/unified")
+req = {
+    "time": 1716796362,
+    "channel": "unified.asset_detail",
+    "event": "subscribe",
+    "payload": ["!all"],
     "auth": {
         "method": "api_key",
         "KEY": "xxxx",
@@ -369,9 +390,9 @@ The above command returns JSON structured like this:
 
 * params
 
-  | parameter    | type         | required | description      |
-  | ------------ | ------------ | -------- | ---------------- |
-  | `currencies` | array string | yes      | asset currencies |
+  | parameter    | type         | required | description                                                                                                                                                                                                     |
+  | ------------ | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `currencies` | array string | yes      | asset currencies. You can specify individual currencies like `["BTC","ETH"]` or use `["!all"]` to subscribe to all currencies. Note: you cannot mix individual currencies with `!all` in the same subscription. |
 
 ## [#](#asset-detail-notification) asset detail notification
 
@@ -456,12 +477,33 @@ The above command returns JSON structured like this:
 import json
 from websocket import create_connection
 
-ws = create_connection("wss://ws.gate.io/v4/ws/unified")
+ws = create_connection("wss://ws.gate.com/v4/ws/unified")
 req = {
     "time": 1716796362,
     "channel": "unified.asset_detail",
     "event": "unsubscribe",
     "payload": ["BTC", "ETH"],
+    "auth": {
+        "method": "api_key",
+        "KEY": "xxxx",
+        "SIGN": "xxxx"
+    }
+}
+ws.send(json.dumps(req))
+print(ws.recv())
+```
+
+```python
+# Unsubscribe from all currencies
+import json
+from websocket import create_connection
+
+ws = create_connection("wss://ws.gate.com/v4/ws/unified")
+req = {
+    "time": 1716796362,
+    "channel": "unified.asset_detail",
+    "event": "unsubscribe",
+    "payload": ["!all"],
     "auth": {
         "method": "api_key",
         "KEY": "xxxx",
@@ -498,4 +540,4 @@ The above command returns JSON structured like this:
 
   `unsubscribe`
 
-Last Updated: 6/12/2025, 7:58:10 AM
+Last Updated: 7/8/2025, 1:29:05 PM


### PR DESCRIPTION
**PR Summary: Gate.io API Documentation Updates (v4.101.1)**

This PR updates multiple sections of the Gate.io API documentation, focusing on the Delivery, Futures, Options, Spot, and Unified Account APIs. The changes include version updates, documentation improvements, and corrections to external links and endpoint descriptions.

**Key Updates:**

- **API Version Update**
  - Updated API version references from `v4.100.3` to `v4.101.1` across all relevant documentation files.

- **External Link Corrections**
  - Updated all references from `gate.io` to `gate.com` for unified trading account documentation and API endpoint documentation links.
  - Ensured all deep links to API endpoint documentation (e.g., order creation, batch orders, order cancellation) now point to the correct `gate.com` domain.

- **Futures Private REST Trading API**
  - Replaced the English description for the "Countdown cancel orders" endpoint with a detailed Chinese explanation, providing improved clarity and usage examples for Chinese-speaking users.
  - Updated parameter descriptions for the countdown cancel orders endpoint for improved clarity and consistency.

- **Futures WebSocket API**
  - Updated all API documentation links to the new `gate.com` domain.
  - Added a detailed field description table for the `req_param` object in the order cancel request section, clarifying required fields such as `order_id`.
  - Improved formatting and consistency in parameter and payload tables for better readability.

- **General Documentation Improvements**
  - Corrected minor typos and improved consistency in terminology (e.g., "Gate.io" to "Gate.com" in example responses).
  - Updated "Last Updated" timestamps in documentation footers where applicable.

**Impacted Documentation Files:**
- `delivery/private_rest_trading_api.md`
- `delivery/websocket_api.md`
- `futures/private_rest_trading_api.md`
- `futures/websocket_api.md`
- `options/private_rest_trading_api.md`
- `options/websocket_api.md`
- `spot/private_rest_account_api.md`
- `spot/private_rest_trading_api.md`
- `spot/websocket_api.md`
- `unified/private_rest_api.md`
- `unified/websocket_api.md`

**Summary:**  
These updates ensure that all API documentation references the latest version, uses correct external links, and provides improved clarity and consistency for both English and Chinese-speaking users. No new endpoints or parameters were introduced; changes are focused on documentation accuracy and usability.