### PR TITLE
BingX API Documentation Update

### DIFF
--- a/docs/bingx/spot/change_log.md
+++ b/docs/bingx/spot/change_log.md
@@ -2,6 +2,11 @@
 
 ## Change Log
 
+2025-07-09
+
+- USDT-M Perp Futures: Removed SNAPSHOT type from 'Account balance and position
+  update push'.
+
 2025-06-30
 
 - USDT-M Perp Futures: Added displayName field to 'USDT-M Perp Futures symbols'


### PR DESCRIPTION
- Updated the change log for BingX Spot API documentation.
- Documented the removal of the SNAPSHOT type from the "Account balance and position update push" for USDT-M Perp Futures as of 2025-07-09.
- No other sections or endpoints were modified in this update.