### PR TITLE
Binance Options API Documentation Update

### DIFF
--- a/docs/binance/options/private_rest_api.md
+++ b/docs/binance/options/private_rest_api.md
@@ -1474,54 +1474,40 @@ Get trades for a specific account and symbol.
 > Source:
 > [https://developers.binance.com/docs/derivatives/option/trade/Account-Trade-List](https://developers.binance.com/docs/derivatives/option/trade/Account-Trade-List)
 
-## Option Margin Account Information (USER_DATA)
+## Get Market Maker Protection Config (TRADE)
 
 ### API Description
 
-Get current account information.
+Get config for MMP.
 
 ### HTTP Request
 
-GET `/eapi/v1/marginAccount`
+GET `/eapi/v1/mmp (HMAC SHA256)`
 
 ### Request Weight
 
-**3**
+**1**
 
 ### Request Parameters
 
-| Name       | Type | Mandatory | Description |
-| ---------- | ---- | --------- | ----------- |
-| recvWindow | LONG | NO        |             |
-| timestamp  | LONG | YES       |             |
+| Name       | Type   | Mandatory | Description             |
+| ---------- | ------ | --------- | ----------------------- |
+| underlying | STRING | TRUE      | underlying, e.g BTCUSDT |
+| recvWindow | LONG   | NO        |                         |
+| timestamp  | LONG   | YES       |                         |
 
 ### Response Example
 
 ```json
 {
-  "asset": [
-    {
-      "asset": "USDT",                  // Asset type
-      "marginBalance": "10099.448"      // Account balance
-      "equity": "10094.44662",          // Account equity
-      "available": "8725.92524",        // Available funds
-      "initialMargin": "1084.52138",    // Initial margin
-      "maintMargin": "151.00138",       // Maintenance margin
-      "unrealizedPNL": "-5.00138",      // Unrealized profit/loss
-      "lpProfit": "-5.00138",           // Unrealized profit for long position
-     }
-  ],
-  "greek": [
-    {
-      "underlying":"BTCUSDT"            // Option Underlying
-      "delta": "-0.05"                  // Account delta
-      "gamma": "-0.002"                 // Account gamma
-      "theta": "-0.05"                  // Account theta
-      "vega": "-0.002"                  // Account vega
-    }
-  ],
-  "time": 1592449455993                 // Time
-}   
+  "underlyingId": 2,
+  "underlying": "BTCUSDT",
+  "windowTimeInMilliseconds": 3000,
+  "frozenTimeInMilliseconds": 300000,
+  "qtyLimit": "2",
+  "deltaLimit": "2.3",
+  "lastTriggerTime": 0
+}
 ```
 
 > Source:

--- a/docs/binance/options/public_rest_api.md
+++ b/docs/binance/options/public_rest_api.md
@@ -720,6 +720,7 @@ NONE
       "unit": 1, // Contract unit, the quantity of the underlying asset represented by a single contract.
       "makerFeeRate": "0.0002", // maker commission rate
       "takerFeeRate": "0.0002", // taker commission rate
+      "liquidationFeeRate": "0.0019000", // liquidation fee rate
       "minQty": "0.01", // Minimum order quantity
       "maxQty": "100", // Maximum order quantity
       "initialMargin": "0.15", // Initial Magin Ratio


### PR DESCRIPTION
**PR Summary: Binance Options API Documentation Updates**

- **Private REST API (`private_rest_api.md`):**
  - Replaced the "Option Margin Account Information (USER_DATA)" section with a new endpoint:
    - **New Endpoint:** "Get Market Maker Protection Config (TRADE)"
      - **Endpoint:** `GET /eapi/v1/mmp (HMAC SHA256)`
      - **Description:** Retrieves Market Maker Protection (MMP) configuration for a specified underlying asset.
      - **Request Parameters:** Updated to include `underlying` (mandatory), `recvWindow` (optional), and `timestamp` (mandatory).
      - **Response Example:** Now documents MMP-related fields such as `underlyingId`, `windowTimeInMilliseconds`, `frozenTimeInMilliseconds`, `qtyLimit`, `deltaLimit`, and `lastTriggerTime`.
    - **Removed:** Previous documentation for the margin account information endpoint, including example response and parameter table.

- **Public REST API (`public_rest_api.md`):**
  - **Endpoint Update:** Enhanced the contract information response example to include a new field:
    - **New Field:** `liquidationFeeRate` – documents the liquidation fee rate for the contract.

**Summary:**  
This PR introduces documentation for a new private endpoint to fetch Market Maker Protection configuration, removes the previous margin account information section, and adds the `liquidationFeeRate` field to the public contract information response example. These changes improve the accuracy and completeness of the Binance Options API documentation.