### PR TITLE
Bullish API Documentation Update

### DIFF
--- a/docs/bullish/private_rest_api.md
+++ b/docs/bullish/private_rest_api.md
@@ -1352,6 +1352,107 @@ Sample:
 }
 ```
 
+## Unified Anonymous Tick WebSocket (unauthenticated)
+
+**Route**
+
+- `/trading-api/v1/market-data/tick`
+
+This allows simultaneous tick subscriptions to multiple markets.
+
+Upon subscribing to a market, the client will first receive a snapshot of latest
+ticker, followed by updates.
+
+### Unified Anonymous Tick Subscription
+
+Tick of different markets to be subscribed to, are controlled by parameters in
+the subscription message listed below: | Parameters | Type | Description |
+|:----------------------|:-------|:--------------------------------------------------------------------------------|
+| topic | String | `tick` | | symbol | String | market symbol such as `BTCUSDC`
+|
+
+### Tick Subscription Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "subscribe",
+  "params": {
+    "topic": "tick",
+    "symbol": "BTCUSD"
+  },
+  "id": "1611082473000"
+}
+```
+
+### Keepalive Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "keepalivePing",
+  "params": {},
+  "id": "1611082473001"
+}
+```
+
+### Tick response example
+
+```json
+{
+  "type": "snapshot",
+  "dataType": "V1TATickerResponse",
+  "data": {
+    "askVolume": "3.56000000",
+    "average": "5200.0400",
+    "baseVolume": "1.00000000",
+    "bestAsk": "6543.0000",
+    "bestBid": "2345.0000",
+    "bidVolume": "2.00000000",
+    "change": "0.0000",
+    "close": "5200.0400",
+    "createdAtTimestamp": "1591058897000",
+    "publishedAtTimestamp": "1591058898000",
+    "high": "5200.0400",
+    "last": "5200.0400",
+    "lastTradeDatetime": "2020-06-02T00:40:39.500Z",
+    "lastTradeSize": "1.00000000",
+    "low": "5200.0400",
+    "open": "5200.0400",
+    "percentage": "0.00",
+    "quoteVolume": "5200.0400",
+    "symbol": "BTC-USDC-PERP",
+    "type": "ticker",
+    "vwap": "5200.0400",
+    "currentPrice": "0.0007",
+    "ammData": [
+      {
+        "feeTierId": "1",
+        "currentPrice": "0.0007",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000005",
+        "askSpreadFee": "0.00000006"
+      },
+      {
+        "feeTierId": "2",
+        "currentPrice": "0.0017",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000015",
+        "askSpreadFee": "0.00000016"
+      }
+    ],
+    "createdAtDatetime": "2020-06-02T00:48:17.000Z",
+    "markPrice": "26000.0000",
+    "fundingRate": "0.114100",
+    "openInterest": "9.00000000"
+  }
+}
+```
+
 ## Anonymous Market Data Price Tick (unauthenticated)
 
 **Route**
@@ -2047,6 +2148,8 @@ Bullish currently has 2 test assets.
 
 ## 2025 Changes
 
+- new Websocket API -
+  [Unified tick for multiple markets](#overview--anonymous-unified-tick-websocket-unauthenticated)
 - June
   - new REST API - [Get Historical Trades](#get-/v1/history/trades)
   - new REST API - [Get Historical Orders](#get-/v2/history/orders)
@@ -8614,6 +8717,7 @@ Get historical derivatives settlement.
 - [supports pagination](#overview--pagination-support)
 - filtering on `settlementDatetime` requires additional keywords,
   [see filtering support](#overview--filtering-support)
+- Only the last 90 days of data is available for querying
 
 <h3 id="get-derivatives-settlement-history-parameters">Parameters</h3>
 
@@ -8860,6 +8964,7 @@ Get historical transfers.
 - [supports pagination](#overview--pagination-support)
 - filtering on `createdAtDatetime` and `createdAtTimestamp` requires additional
   keywords, [see filtering support](#overview--filtering-support)
+- Only the last 90 days of data is available for querying
 
 <h3 id="get-transfer-history-parameters">Parameters</h3>
 
@@ -9046,6 +9151,8 @@ of data at a time.
 - [supports pagination](#overview--pagination-support)
 
 **Ratelimited:** `False`
+
+- Only the last 90 days of data is available for querying
 
 <h3 id="market-data-get-historical-anonymous-trades-by-market-symbol-parameters">Parameters</h3>
 
@@ -9239,6 +9346,7 @@ _Get Historical Funding Rate_
 Get historical hourly funding rate for the requested perpetual market
 
 - [supports pagination](#overview--pagination-support)
+- Only the last 90 days of data is available for querying
 
 <h3 id="market-data-get-funding-rate-history-by-market-symbol-parameters">Parameters</h3>
 
@@ -9359,6 +9467,7 @@ charged in the particular hour for the asset.
 - [supports pagination](#overview--pagination-support)
 - filtering `createdAtDatetime`, `createdAtTimestamp` requires additional
   keywords, [see filtering support](#overview--filtering-support)
+- Only the last 90 days of data is available for querying
 
 **Ratelimited:** `True`
 
@@ -17361,6 +17470,12 @@ unique asset ID
       "type": "boolean",
       "example": true
     },
+    "amendOrderEnabled": {
+      "description": "able to amend order",
+      "type": "boolean",
+      "example": true,
+      "deprecated": true
+    },
     "cancelOrderEnabled": {
       "description": "able to cancel order",
       "type": "boolean",
@@ -17502,6 +17617,7 @@ unique asset ID
 | marginTradingEnabled          | boolean                                         | true     | none         | margin trading enabled (only applies for Spot markets)                                                                                                                                                   |
 | marketEnabled                 | boolean                                         | true     | none         | market enabled                                                                                                                                                                                           |
 | createOrderEnabled            | boolean                                         | true     | none         | able to create order                                                                                                                                                                                     |
+| amendOrderEnabled             | boolean                                         | false    | none         | able to amend order                                                                                                                                                                                      |
 | cancelOrderEnabled            | boolean                                         | true     | none         | able to cancel order                                                                                                                                                                                     |
 | liquidityInvestEnabled        | boolean                                         | true     | none         | able to invest liquidity to market.                                                                                                                                                                      |
 | liquidityWithdrawEnabled      | boolean                                         | true     | none         | able to withdraw liquidity from market.                                                                                                                                                                  |

--- a/docs/bullish/public_rest_api.md
+++ b/docs/bullish/public_rest_api.md
@@ -1352,6 +1352,107 @@ Sample:
 }
 ```
 
+## Unified Anonymous Tick WebSocket (unauthenticated)
+
+**Route**
+
+- `/trading-api/v1/market-data/tick`
+
+This allows simultaneous tick subscriptions to multiple markets.
+
+Upon subscribing to a market, the client will first receive a snapshot of latest
+ticker, followed by updates.
+
+### Unified Anonymous Tick Subscription
+
+Tick of different markets to be subscribed to, are controlled by parameters in
+the subscription message listed below: | Parameters | Type | Description |
+|:----------------------|:-------|:--------------------------------------------------------------------------------|
+| topic | String | `tick` | | symbol | String | market symbol such as `BTCUSDC`
+|
+
+### Tick Subscription Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "subscribe",
+  "params": {
+    "topic": "tick",
+    "symbol": "BTCUSD"
+  },
+  "id": "1611082473000"
+}
+```
+
+### Keepalive Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "keepalivePing",
+  "params": {},
+  "id": "1611082473001"
+}
+```
+
+### Tick response example
+
+```json
+{
+  "type": "snapshot",
+  "dataType": "V1TATickerResponse",
+  "data": {
+    "askVolume": "3.56000000",
+    "average": "5200.0400",
+    "baseVolume": "1.00000000",
+    "bestAsk": "6543.0000",
+    "bestBid": "2345.0000",
+    "bidVolume": "2.00000000",
+    "change": "0.0000",
+    "close": "5200.0400",
+    "createdAtTimestamp": "1591058897000",
+    "publishedAtTimestamp": "1591058898000",
+    "high": "5200.0400",
+    "last": "5200.0400",
+    "lastTradeDatetime": "2020-06-02T00:40:39.500Z",
+    "lastTradeSize": "1.00000000",
+    "low": "5200.0400",
+    "open": "5200.0400",
+    "percentage": "0.00",
+    "quoteVolume": "5200.0400",
+    "symbol": "BTC-USDC-PERP",
+    "type": "ticker",
+    "vwap": "5200.0400",
+    "currentPrice": "0.0007",
+    "ammData": [
+      {
+        "feeTierId": "1",
+        "currentPrice": "0.0007",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000005",
+        "askSpreadFee": "0.00000006"
+      },
+      {
+        "feeTierId": "2",
+        "currentPrice": "0.0017",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000015",
+        "askSpreadFee": "0.00000016"
+      }
+    ],
+    "createdAtDatetime": "2020-06-02T00:48:17.000Z",
+    "markPrice": "26000.0000",
+    "fundingRate": "0.114100",
+    "openInterest": "9.00000000"
+  }
+}
+```
+
 ## Anonymous Market Data Price Tick (unauthenticated)
 
 **Route**
@@ -2047,6 +2148,8 @@ Bullish currently has 2 test assets.
 
 ## 2025 Changes
 
+- new Websocket API -
+  [Unified tick for multiple markets](#overview--anonymous-unified-tick-websocket-unauthenticated)
 - June
   - new REST API - [Get Historical Trades](#get-/v1/history/trades)
   - new REST API - [Get Historical Orders](#get-/v2/history/orders)
@@ -3334,6 +3437,12 @@ Get Markets. Clients can ignore [test markets](#overview--test-markets). Note ->
         "type": "boolean",
         "example": true
       },
+      "amendOrderEnabled": {
+        "description": "able to amend order",
+        "type": "boolean",
+        "example": true,
+        "deprecated": true
+      },
       "cancelOrderEnabled": {
         "description": "able to cancel order",
         "type": "boolean",
@@ -3488,6 +3597,7 @@ Status Code **200**
 | » marginTradingEnabled          | boolean                                         | true     | none         | margin trading enabled (only applies for Spot markets)                                                                                                                                                   |
 | » marketEnabled                 | boolean                                         | true     | none         | market enabled                                                                                                                                                                                           |
 | » createOrderEnabled            | boolean                                         | true     | none         | able to create order                                                                                                                                                                                     |
+| » amendOrderEnabled             | boolean                                         | false    | none         | able to amend order                                                                                                                                                                                      |
 | » cancelOrderEnabled            | boolean                                         | true     | none         | able to cancel order                                                                                                                                                                                     |
 | » liquidityInvestEnabled        | boolean                                         | true     | none         | able to invest liquidity to market.                                                                                                                                                                      |
 | » liquidityWithdrawEnabled      | boolean                                         | true     | none         | able to withdraw liquidity from market.                                                                                                                                                                  |
@@ -3861,6 +3971,12 @@ Get Market by Symbol. Note -> "Leverage = Collateral ÷ (Collateral - Debt)"
       "description": "able to create order",
       "type": "boolean",
       "example": true
+    },
+    "amendOrderEnabled": {
+      "description": "able to amend order",
+      "type": "boolean",
+      "example": true,
+      "deprecated": true
     },
     "cancelOrderEnabled": {
       "description": "able to cancel order",

--- a/docs/bullish/websocket_api.md
+++ b/docs/bullish/websocket_api.md
@@ -1352,6 +1352,107 @@ Sample:
 }
 ```
 
+## Unified Anonymous Tick WebSocket (unauthenticated)
+
+**Route**
+
+- `/trading-api/v1/market-data/tick`
+
+This allows simultaneous tick subscriptions to multiple markets.
+
+Upon subscribing to a market, the client will first receive a snapshot of latest
+ticker, followed by updates.
+
+### Unified Anonymous Tick Subscription
+
+Tick of different markets to be subscribed to, are controlled by parameters in
+the subscription message listed below: | Parameters | Type | Description |
+|:----------------------|:-------|:--------------------------------------------------------------------------------|
+| topic | String | `tick` | | symbol | String | market symbol such as `BTCUSDC`
+|
+
+### Tick Subscription Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "subscribe",
+  "params": {
+    "topic": "tick",
+    "symbol": "BTCUSD"
+  },
+  "id": "1611082473000"
+}
+```
+
+### Keepalive Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "keepalivePing",
+  "params": {},
+  "id": "1611082473001"
+}
+```
+
+### Tick response example
+
+```json
+{
+  "type": "snapshot",
+  "dataType": "V1TATickerResponse",
+  "data": {
+    "askVolume": "3.56000000",
+    "average": "5200.0400",
+    "baseVolume": "1.00000000",
+    "bestAsk": "6543.0000",
+    "bestBid": "2345.0000",
+    "bidVolume": "2.00000000",
+    "change": "0.0000",
+    "close": "5200.0400",
+    "createdAtTimestamp": "1591058897000",
+    "publishedAtTimestamp": "1591058898000",
+    "high": "5200.0400",
+    "last": "5200.0400",
+    "lastTradeDatetime": "2020-06-02T00:40:39.500Z",
+    "lastTradeSize": "1.00000000",
+    "low": "5200.0400",
+    "open": "5200.0400",
+    "percentage": "0.00",
+    "quoteVolume": "5200.0400",
+    "symbol": "BTC-USDC-PERP",
+    "type": "ticker",
+    "vwap": "5200.0400",
+    "currentPrice": "0.0007",
+    "ammData": [
+      {
+        "feeTierId": "1",
+        "currentPrice": "0.0007",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000005",
+        "askSpreadFee": "0.00000006"
+      },
+      {
+        "feeTierId": "2",
+        "currentPrice": "0.0017",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000015",
+        "askSpreadFee": "0.00000016"
+      }
+    ],
+    "createdAtDatetime": "2020-06-02T00:48:17.000Z",
+    "markPrice": "26000.0000",
+    "fundingRate": "0.114100",
+    "openInterest": "9.00000000"
+  }
+}
+```
+
 ## Anonymous Market Data Price Tick (unauthenticated)
 
 **Route**
@@ -2047,6 +2148,8 @@ Bullish currently has 2 test assets.
 
 ## 2025 Changes
 
+- new Websocket API -
+  [Unified tick for multiple markets](#overview--anonymous-unified-tick-websocket-unauthenticated)
 - June
   - new REST API - [Get Historical Trades](#get-/v1/history/trades)
   - new REST API - [Get Historical Orders](#get-/v2/history/orders)
@@ -2901,6 +3004,107 @@ Sample:
     "createdAtTimestamp": "1722408780786",
     "publishedAtTimestamp": "1722408780790",
     "symbol": "BTCUSDC"
+  }
+}
+```
+
+## Unified Anonymous Tick WebSocket (unauthenticated)
+
+**Route**
+
+- `/trading-api/v1/market-data/tick`
+
+This allows simultaneous tick subscriptions to multiple markets.
+
+Upon subscribing to a market, the client will first receive a snapshot of latest
+ticker, followed by updates.
+
+### Unified Anonymous Tick Subscription
+
+Tick of different markets to be subscribed to, are controlled by parameters in
+the subscription message listed below: | Parameters | Type | Description |
+|:----------------------|:-------|:--------------------------------------------------------------------------------|
+| topic | String | `tick` | | symbol | String | market symbol such as `BTCUSDC`
+|
+
+### Tick Subscription Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "subscribe",
+  "params": {
+    "topic": "tick",
+    "symbol": "BTCUSD"
+  },
+  "id": "1611082473000"
+}
+```
+
+### Keepalive Message Sample:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "type": "command",
+  "method": "keepalivePing",
+  "params": {},
+  "id": "1611082473001"
+}
+```
+
+### Tick response example
+
+```json
+{
+  "type": "snapshot",
+  "dataType": "V1TATickerResponse",
+  "data": {
+    "askVolume": "3.56000000",
+    "average": "5200.0400",
+    "baseVolume": "1.00000000",
+    "bestAsk": "6543.0000",
+    "bestBid": "2345.0000",
+    "bidVolume": "2.00000000",
+    "change": "0.0000",
+    "close": "5200.0400",
+    "createdAtTimestamp": "1591058897000",
+    "publishedAtTimestamp": "1591058898000",
+    "high": "5200.0400",
+    "last": "5200.0400",
+    "lastTradeDatetime": "2020-06-02T00:40:39.500Z",
+    "lastTradeSize": "1.00000000",
+    "low": "5200.0400",
+    "open": "5200.0400",
+    "percentage": "0.00",
+    "quoteVolume": "5200.0400",
+    "symbol": "BTC-USDC-PERP",
+    "type": "ticker",
+    "vwap": "5200.0400",
+    "currentPrice": "0.0007",
+    "ammData": [
+      {
+        "feeTierId": "1",
+        "currentPrice": "0.0007",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000005",
+        "askSpreadFee": "0.00000006"
+      },
+      {
+        "feeTierId": "2",
+        "currentPrice": "0.0017",
+        "baseReservesQuantity": "96153.00000000",
+        "quoteReservesQuantity": "500005200.0400",
+        "bidSpreadFee": "0.00000015",
+        "askSpreadFee": "0.00000016"
+      }
+    ],
+    "createdAtDatetime": "2020-06-02T00:48:17.000Z",
+    "markPrice": "26000.0000",
+    "fundingRate": "0.114100",
+    "openInterest": "9.00000000"
   }
 }
 ```


### PR DESCRIPTION
**PR Summary: API Documentation Updates**

- **New WebSocket Endpoint: Unified Anonymous Tick WebSocket**
  - Added documentation for a new unauthenticated WebSocket endpoint: `/trading-api/v1/market-data/tick`.
  - Enables clients to subscribe to tick data for multiple markets simultaneously.
  - Includes details on subscription parameters, sample subscription and keepalive messages, and example tick response payloads.
  - Clarifies that clients receive an initial snapshot followed by real-time updates.

- **Changelog/Release Notes Updates**
  - Updated the "2025 Changes" section to announce the new Unified Tick WebSocket API for multiple markets.

- **Market Data History Endpoints: Data Availability Clarification**
  - Added notes to several historical data endpoints (e.g., settlement history, transfer history, trade history, funding rate history) specifying that only the last 90 days of data are available for querying.

- **Market Object Schema Updates**
  - Added the `amendOrderEnabled` boolean property to the market object in both the private and public REST API documentation.
    - Marked as deprecated.
    - Updated schema tables and example responses accordingly.

- **General Documentation Enhancements**
  - Improved parameter tables and descriptions for new and updated endpoints.
  - Provided additional usage examples for new WebSocket functionality.

These changes enhance the clarity and completeness of the API documentation, particularly around real-time market data access and market object capabilities.