### PR TITLE
BingX API Documentation Update

### DIFF
--- a/docs/bingx/spot/public_websocket_api.md
+++ b/docs/bingx/spot/public_websocket_api.md
@@ -332,9 +332,11 @@ Subscription Parameters
 
 #### Request Parameters
 
-| Parameter Name | Type   | Required | Field Description                                                    |
-| -------------- | ------ | -------- | -------------------------------------------------------------------- |
-| symbol         | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USDT |
+| Parameter Name | Type   | Required | Field Description                                                   |
+| -------------- | ------ | -------- | ------------------------------------------------------------------- |
+| id             | string | yes      | Subscription ID                                                     |
+| reqType        | string | yes      | Request type: Subscribe - sub; Unsubscribe - unsub                  |
+| dataType       | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USD |
 
 #### Data Parameters
 
@@ -372,10 +374,11 @@ Subscription Parameters
 
 #### Request Parameters
 
-| Parameter Name | Type   | Required | Field Description                                                    |
-| -------------- | ------ | -------- | -------------------------------------------------------------------- |
-| symbol         | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USDT |
-| interval       | string | yes      | Reference field description, K-line type                             |
+| Parameter Name | Type   | Required | Field Description                                                                                            |
+| -------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------ |
+| id             | string | yes      | Subscription ID                                                                                              |
+| reqType        | string | yes      | Request type: Subscribe - sub; Unsubscribe - unsub                                                           |
+| dataType       | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USD.Reference field description, K-line type |
 
 #### Data Parameters
 
@@ -424,9 +427,11 @@ Subscription Parameters
 
 #### Request Parameters
 
-| Parameter Name | Type   | Required | Field Description                                                    |
-| -------------- | ------ | -------- | -------------------------------------------------------------------- |
-| symbol         | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USDT |
+| Parameter Name | Type   | Required | Field Description                                                                                            |
+| -------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------ |
+| id             | string | yes      | Subscription ID                                                                                              |
+| reqType        | string | yes      | Request type: Subscribe - sub; Unsubscribe - unsub                                                           |
+| dataType       | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USD.Reference field description, K-line type |
 
 #### Order Parameters
 
@@ -461,9 +466,11 @@ Subscription Parameters
 
 #### Request Parameters
 
-| Parameter Name | Type   | Required | Field Description            |
-| -------------- | ------ | -------- | ---------------------------- |
-| symbol         | string | Yes      | Trading pair, e.g., BTC-USDT |
+| Parameter Name | Type   | Required | Field Description                                                   |
+| -------------- | ------ | -------- | ------------------------------------------------------------------- |
+| id             | string | yes      | Subscription ID                                                     |
+| reqType        | string | yes      | Request type: Subscribe - sub; Unsubscribe - unsub                  |
+| dataType       | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USD |
 
 > **Source:**
 > [https://bingx-api.github.io/docs/#/en-us/spot/socket/market.html#Subscribe to
@@ -488,9 +495,11 @@ Subscription Parameters
 
 #### Request Parameters
 
-| Parameter Name | Type   | Required | Field Description            |
-| -------------- | ------ | -------- | ---------------------------- |
-| symbol         | string | Yes      | Trading pair, e.g., BTC-USDT |
+| Parameter Name | Type   | Required | Field Description                                                   |
+| -------------- | ------ | -------- | ------------------------------------------------------------------- |
+| id             | string | yes      | Subscription ID                                                     |
+| reqType        | string | yes      | Request type: Subscribe - sub; Unsubscribe - unsub                  |
+| dataType       | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USD |
 
 > **Source:**
 > [https://bingx-api.github.io/docs/#/en-us/spot/socket/market.html#Spot Latest
@@ -515,9 +524,11 @@ Subscription Parameters
 
 #### Request Parameters
 
-| Parameter Name | Type   | Required | Field Description            |
-| -------------- | ------ | -------- | ---------------------------- |
-| symbol         | string | Yes      | Trading pair, e.g., BTC-USDT |
+| Parameter Name | Type   | Required | Field Description                                                   |
+| -------------- | ------ | -------- | ------------------------------------------------------------------- |
+| id             | string | yes      | Subscription ID                                                     |
+| reqType        | string | yes      | Request type: Subscribe - sub; Unsubscribe - unsub                  |
+| dataType       | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USD |
 
 > **Source:**
 > [https://bingx-api.github.io/docs/#/en-us/spot/socket/market.html#Spot Best
@@ -575,9 +586,11 @@ Subscription Parameters
 
 #### Request Parameters
 
-| Parameter Name | Type   | Required | Field Description                                        |
-| -------------- | ------ | -------- | -------------------------------------------------------- |
-| symbol         | string | Yes      | Symbol name, the symbol must include a '-' like BTC-USDT |
+| Parameter Name | Type   | Required | Field Description                                                   |
+| -------------- | ------ | -------- | ------------------------------------------------------------------- |
+| id             | string | yes      | Subscription ID                                                     |
+| reqType        | string | yes      | Request type: Subscribe - sub; Unsubscribe - unsub                  |
+| dataType       | string | yes      | There must be a hyphen/ "-" in the trading pair symbol. eg: BTC-USD |
 
 > **Source:**
 > [https://bingx-api.github.io/docs/#/en-us/spot/socket/market.html#Incremental


### PR DESCRIPTION
**PR Summary: Update to BingX Spot Public WebSocket API Documentation**

- **Modified Sections:**  
  Updated the "Request Parameters" tables for multiple public WebSocket subscription endpoints in `docs/bingx/spot/public_websocket_api.md`.

- **Parameter Updates:**  
  - Replaced the single `symbol` (or `symbol`/`interval`) parameter with three new parameters for all relevant subscription endpoints:
    - `id` (string, required): Subscription ID
    - `reqType` (string, required): Request type, with allowed values `sub` (Subscribe) and `unsub` (Unsubscribe)
    - `dataType` (string, required): Trading pair symbol, must include a hyphen (e.g., BTC-USD), with additional context for some endpoints (e.g., K-line type)
  - Removed the previous `symbol` and `interval` parameters from these request tables.

- **Documentation Improvements:**  
  - Enhanced field descriptions for the new parameters, clarifying requirements and expected formats.
  - Standardized parameter naming and descriptions across all affected endpoints for consistency.

- **Endpoints Affected:**  
  The following WebSocket subscription endpoints had their request parameter documentation updated:
    - Market Ticker subscription
    - K-line (candlestick) data subscription
    - Order Book Depth subscription
    - Trade subscription
    - Latest Price subscription
    - Best Bid/Ask subscription
    - Incremental Depth subscription

- **Purpose:**  
  These changes align the documentation with the current API request structure and improve clarity for developers integrating with BingX Spot public WebSocket endpoints.