### PR TITLE
MEXC API Documentation Update

### DIFF
--- a/docs/mexc/spot/private_rest_api.md
+++ b/docs/mexc/spot/private_rest_api.md
@@ -837,7 +837,7 @@ Parameters:
 
 | Name              | Type   | Mandatory | Description |
 | ----------------- | ------ | --------- | ----------- |
-| symbol            | String | YES       |             |
+| symbol            | String | No        |             |
 | origClientOrderId | String | NO        |             |
 | orderId           | String | NO        |             |
 | recvWindow        | long   | NO        |             |

--- a/docs/mexc/spot/public_websocket_api.md
+++ b/docs/mexc/spot/public_websocket_api.md
@@ -378,7 +378,8 @@ Available intervals:
       }
     ],
     "eventtype": "spot@public.aggre.depth.v3.api.pb@100ms", // Event type
-    "version": "36913293511" // Version number
+    "fromVersion" : "10589632359", // from Version number
+    "toVersion" : "10589632359" // to Version number
   },
   "symbol": "BTCUSDT", // Trading pair
   "sendtime": 1736411507002 // Event time
@@ -393,101 +394,15 @@ be removed.
 
 **Response Parameters:**
 
-| Parameter | Data Type | Description           |
-| --------- | --------- | --------------------- |
-| price     | string    | Price level of change |
-| quantity  | string    | Quantity              |
-| eventtype | string    | Event type            |
-| version   | string    | Version number        |
-| symbol    | string    | Trading pair          |
-| sendtime  | long      | Event time            |
-
----
-
-## Diff.Depth Stream(Batch Aggregation)
-
-> **Request:**
-
-```
-{
-    "method": "SUBSCRIPTION",
-    "params": [
-        "spot@public.increase.depth.batch.v3.api.pb@BTCUSDT"
-    ]
-}
-```
-
-> **Response:**
-
-```
-{
-  "channel" : "spot@public.increase.depth.batch.v3.api.pb@BTCUSDT",
-  "symbol" : "BTCUSDT",
-  "sendTime" : "1739502064578",
-  "publicIncreaseDepthsBatch" : {
-    "items" : [ {
-      "asks" : [ ],
-      "bids" : [ {
-        "price" : "96578.48",
-        "quantity" : "0.00000000"
-      } ],
-      "eventType" : "",
-      "version" : "39003145507"
-    }, {
-      "asks" : [ ],
-      "bids" : [ {
-        "price" : "96578.90",
-        "quantity" : "0.00000000"
-      } ],
-      "eventType" : "",
-      "version" : "39003145508"
-    }, {
-      "asks" : [ ],
-      "bids" : [ {
-        "price" : "96579.31",
-        "quantity" : "0.00000000"
-      } ],
-      "eventType" : "",
-      "version" : "39003145509"
-    }, {
-      "asks" : [ ],
-      "bids" : [ {
-        "price" : "96579.84",
-        "quantity" : "0.00000000"
-      } ],
-      "eventType" : "",
-      "version" : "39003145510"
-    }, {
-      "asks" : [ ],
-      "bids" : [ {
-        "price" : "96576.69",
-        "quantity" : "4.88725694"
-      } ],
-      "eventType" : "",
-      "version" : "39003145511"
-    } ],
-    "eventType" : "spot@public.increase.depth.batch.v3.api.pb"
-  }
-}
-```
-
-In the batch aggregation version, if the number of entries exceeds 5 or the time
-interval exceeds 5ms, the data is pushed once. If the order quantity for a price
-level is 0, it indicates that the order at that price has been canceled or
-executed, and that price level should be removed.
-
-**Request Parameter:** `spot@public.increase.depth.batch.v3.api.pb@<symbol>`
-
-**Response Parameters:**
-
-| Parameter | Data Type | Description           |
-| --------- | --------- | --------------------- |
-| price     | string    | Price level of change |
-| quantity  | string    | Quantity              |
-| eventtype | string    | Event type            |
-| version   | string    | Version number        |
-| symbol    | string    | Trading pair          |
-| sendtime  | long      | Event time            |
+| Parameter   | Data Type | Description           |
+| ----------- | --------- | --------------------- |
+| price       | string    | Price level of change |
+| quantity    | string    | Quantity              |
+| eventtype   | string    | Event type            |
+| fromversion | string    | From Version number   |
+| toversion   | string    | To Version number     |
+| symbol      | string    | Trading pair          |
+| sendtime    | long      | Event time            |
 
 ---
 


### PR DESCRIPTION
**PR Summary:**

This PR updates the documentation for the MEXC Spot API, focusing on both the Private REST API and the Public WebSocket API. The following changes were made:

- **Private REST API Documentation (`private_rest_api.md`):**
  - Updated the parameter requirements for an endpoint (likely related to order management):
    - Changed the `symbol` parameter from **Mandatory (YES)** to **Optional (No)**.

- **Public WebSocket API Documentation (`public_websocket_api.md`):**
  - Enhanced the response example for the `spot@public.aggre.depth.v3.api.pb@100ms` stream:
    - Added `fromVersion` and `toVersion` fields to the response sample, improving clarity on version tracking.
  - Updated the **Response Parameters** table:
    - Replaced the single `version` field with `fromversion` and `toversion` to reflect the new response structure.
  - Removed the entire section for the **Diff.Depth Stream (Batch Aggregation)**:
    - Deleted request/response examples, parameter tables, and explanatory notes for the batch aggregation stream (`spot@public.increase.depth.batch.v3.api.pb`).
    - This stream and its documentation are no longer present in the public WebSocket API docs.

These changes improve parameter clarity, update versioning information, and remove deprecated or unsupported WebSocket stream documentation.