### PR TITLE
Binance USDM API Documentation Update

### DIFF
--- a/docs/binance/futures/change_log.md
+++ b/docs/binance/futures/change_log.md
@@ -2,6 +2,13 @@
 
 ## Change Log
 
+### 2025-07-25
+
+- Added new error code in fapi:
+  - `-4109`: _This account is inactive. Please activate it before trading._  
+    This indicates the account has been archived due to inactivity. To activate
+    it, transfer any amount of asset to the USDM Futures account.
+
 ### 2025-07-02
 
 USDⓈ-M Futures


### PR DESCRIPTION
- Updated the Binance Futures API documentation change log.
- Documented the addition of a new error code for the fapi endpoints:
  - Error code `-4109`: Indicates that the account is inactive and must be activated before trading. The documentation now explains that accounts may be archived due to inactivity and can be reactivated by transferring any asset to the USDM Futures account.
- No new endpoints or parameter changes were introduced; this update improves error handling documentation.