### PR TITLE
Binance USDM API Documentation Update

### DIFF
--- a/docs/binance/futures/change_log.md
+++ b/docs/binance/futures/change_log.md
@@ -2,6 +2,19 @@
 
 ## Change Log
 
+### 2025-08-11
+
+- BFUSD will be migrated to Binance Earn on 2025-08-13. The following endpoints
+  will be deprecated after the migration:
+  - `POST sapi/v1/portfolio/mint`
+  - `POST sapi/v1/portfolio/redeem`
+- Error code `-21015` ENDPOINT_GONE will be encountered.
+- Portfolio Margin and Portfolio Margin Pro users can switch to Binance Earn for
+  BFUSD minting and redeeming. After the migration, the existing BFUSD under the
+  Portfolio Margin wallet can use the aggregate balance
+  function(`POST /sapi/v1/portfolio/asset-collection`) first, and transfer from
+  Portfolio Margin wallet to Spot wallet for redemption.
+
 ### 2025-07-25
 
 - Added new error code in fapi:


### PR DESCRIPTION
- Updated the Binance Futures API documentation change log to announce the upcoming migration of BFUSD to Binance Earn, effective 2025-08-13.
- Documented the deprecation of the following endpoints after the migration:
  - POST /sapi/v1/portfolio/mint
  - POST /sapi/v1/portfolio/redeem
- Added information about the new error code -21015 (ENDPOINT_GONE) that will be returned when accessing deprecated endpoints.
- Provided guidance for Portfolio Margin and Portfolio Margin Pro users regarding switching to Binance Earn for BFUSD minting and redeeming.
- Included instructions for users on how to transfer existing BFUSD from Portfolio Margin wallet to Spot wallet for redemption using the aggregate balance function (POST /sapi/v1/portfolio/asset-collection).