### PR TITLE
BingX API Documentation Update

### DIFF
--- a/docs/bingx/spot/change_log.md
+++ b/docs/bingx/spot/change_log.md
@@ -2,6 +2,22 @@
 
 ## Change Log
 
+2025-08-21
+
+- USDT-M Perp Futures:API and Websocket do not support foreign exchange
+  currencies
+- USDT-M Perp Futures:The positionId field has been added to the response of the
+  query all current open orders API.
+- USDT-M Perp Futures:Fixed the issue where clientOrderId was empty in the TP
+  order cancellation API and order query API.
+- USDT-M Perp Futures:Fixed the incorrect response issue in the set position
+  mode API.
+- USDT-M Perp Futures:Removed the INDEX_PRICE type from the workingType field in
+  the order API.
+- Accounts & Wallets:Optimized the withdrawal API. When the funding account
+  balance is insufficient, the system will automatically replenish funds from
+  the spot account.
+
 2025-07-11
 
 - Accounts & Wallets: Added wallType field to responses for 'Main Account

--- a/docs/bingx/spot/private_rest_api.md
+++ b/docs/bingx/spot/private_rest_api.md
@@ -612,7 +612,7 @@ Specify user account to initiate coin withdrawal
 | address            | string  | yes      | Withdrawal address                                                                                                                                                                                               |
 | addressTag         | string  | no       | Tag or memo, some currencies support tag or memo                                                                                                                                                                 |
 | amount             | float64 | yes      | Withdrawal amount                                                                                                                                                                                                |
-| walletType         | int64   | yes      | Account type: 1 fund account, 2 standard account, 3 perpetual account, 15 spot account                                                                                                                           |
+| walletType         | int64   | yes      | Account type: 1 fund account, 2 standard account, 3 perpetual account, 15 spot account.When the funding account balance is insufficient, the system will automatically replenish funds from the spot account.    |
 | withdrawOrderId    | string  | no       | Customer-defined withdrawal ID, a combination of numbers and letters, with a length of less than 100 characters                                                                                                  |
 | vaspEntityId       | string  | no       | Payment platform information, only KYC=KOR (Korean individual users) must pass this field. List values Bithumb, Coinone, Hexlant, Korbit, Upbit, Others, and select Others if there are no corresponding options |
 | recipientLastName  | string  | no       | The recipient's surname is in English, and only KYC=KOR (Korean individual users) must pass this field. No need to fill in when vaspAntityId=Others                                                              |
@@ -1223,6 +1223,7 @@ records. Only available for parent users.
 
 | Parameter Name   | Type   | Required | Description                                                                                                                                               |
 | ---------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id               | string | no       | Internal transfer ID                                                                                                                                      |
 | coin             | string | Yes      | Transfer coin name                                                                                                                                        |
 | transferClientId | string | no       | Client's self-defined internal transfer ID. When both platform ID and transferClientId are provided as input, the query will be based on the platform ID. |
 | startTime        | long   | No       | Start time                                                                                                                                                |

--- a/docs/bingx/spot/public_rest_api.md
+++ b/docs/bingx/spot/public_rest_api.md
@@ -303,7 +303,7 @@ rate limitation by IP in group Number: 1
 | maxQty         | float64 | Version upgrade, this field is deprecated, please ignore this field,the formula is: maxQty = maxNotional/price                                |
 | minNotional    | float64 | Minimum transaction amount                                                                                                                    |
 | maxNotional    | float64 | Maximum transaction amount                                                                                                                    |
-| status         | int     | 0 offline, 1 online, 5 pre-open, 25 trading suspended                                                                                         |
+| status         | int     | 0 offline, 1 online, 5 pre-open, 10 accessed 25 trading suspended                                                                             |
 | apiStateBuy    | Boolean | available buy via api                                                                                                                         |
 | apiStateSell   | Boolean | available sell via api                                                                                                                        |
 | timeOnline     | long    | online time                                                                                                                                   |
@@ -577,7 +577,7 @@ rate limitation by IP in group Number: 1
 
 | Parameter Name | Type   | Required | Description                                                                           |
 | -------------- | ------ | -------- | ------------------------------------------------------------------------------------- |
-| symbol         | string | Yes      | Trading pair, such as: BTC_USDT                                                       |
+| symbol         | string | Yes      | Trading pair, such as: BTC-USDT                                                       |
 | depth          | int64  | Yes      | Query depth                                                                           |
 | type           | string | Yes      | step0 default precision, step1 to step5 are 10 to 100000 times precision respectively |
 

--- a/docs/bingx/spot/public_websocket_api.md
+++ b/docs/bingx/spot/public_websocket_api.md
@@ -455,7 +455,7 @@ Pushes data of 24-hour price change every 1000ms
 
 Subscription Type
 
-dataType is <symbol>@ticker, for example, BTC_USDT@ticker
+dataType is <symbol>@ticker, for example, BTC-USDT@ticker
 
 Subscription Example
 
@@ -484,7 +484,7 @@ Real-time Push
 
 Subscription Type
 
-dataType is <symbol>@lastPrice, for example, BTC_USDT@lastPrice
+dataType is <symbol>@lastPrice, for example, BTC-USDT@lastPrice
 
 Subscription Example
 
@@ -513,7 +513,7 @@ Real-time Push
 
 Subscription Type
 
-dataType is <symbol>@bookTicker, for example, BTC_USDT@bookTicker
+dataType is <symbol>@bookTicker, for example, BTC-USDT@bookTicker
 
 Subscription Example
 


### PR DESCRIPTION
**PR Summary: Cryptocurrency Exchange API Documentation Updates**

The following documentation updates were made across multiple API sections:

---

**Change Log Updates**
- Added 2025-08-21 release notes highlighting:
  - USDT-M Perp Futures API and WebSocket no longer support foreign exchange currencies.
  - Added positionId field to the response of the "query all current open orders" API.
  - Fixed empty clientOrderId in TP order cancellation and order query APIs.
  - Corrected response for the set position mode API.
  - Removed INDEX_PRICE type from the workingType field in the order API.
  - Enhanced withdrawal API: if the funding account balance is insufficient, funds are now automatically replenished from the spot account.

---

**Private REST API Documentation**
- **Withdrawal API**
  - Updated the walletType parameter description to clarify that the system will automatically replenish funds from the spot account if the funding account balance is insufficient.
- **Internal Transfer Query API**
  - Added a new optional parameter: id (Internal transfer ID).

---

**Public REST API Documentation**
- **Trading Pair Status**
  - Updated status field description: added value 10 ("accessed") to the possible status codes.
- **Order Book API**
  - Updated symbol parameter example from BTC_USDT to BTC-USDT for consistency with current naming conventions.

---

**Public WebSocket API Documentation**
- Updated all symbol examples from the format BTC_USDT to BTC-USDT in:
  - Ticker subscription
  - Last price subscription
  - Book ticker subscription

---

These changes improve clarity, enhance parameter documentation, and ensure consistency across API references.