### PR TITLE
Crypto.com API Documentation Update

### DIFF
--- a/docs/cryptocom/private_rest_api.md
+++ b/docs/cryptocom/private_rest_api.md
@@ -53,6 +53,16 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-07-17
+
+  - `private/fiat/fiat-deposit-info` was added
+  - `private/fiat/fiat-deposit-history` was added
+  - `private/fiat/fiat-withdraw-history` was added
+  - `private/fiat/fiat-create-withdraw` was added
+  - `private/fiat/fiat-get-bank-accounts` was added
+  - `private/fiat/fiat-transaction-quota` was added
+  - `private/fiat/fiat-transaction-limit` was added
+
 - 2025-07-04
 
   - `private/create-order` exec_inst was added `SMART_POST_ONLY`
@@ -1767,7 +1777,8 @@ that the request is queued.
       "params": {
         "instrument_name": "BTCUSD-PERP",
         "type": "LIMIT",
-        "price": "30000.0"
+        "price": "30000.0",
+        "quantity": "1000"
       }
     }
 
@@ -1803,11 +1814,15 @@ successfully canceled.
 
 ### Request Params
 
-| Name            | Type   | Required | Description             |
-| --------------- | ------ | -------- | ----------------------- |
-| instrument_name | string | Y        | e.g. BTCUSD-PERP        |
-| type            | string | Y        | `LIMIT` or `MARKET`     |
-| price           | string | Depends  | For `LIMIT` orders only |
+| Name            | Type             | Required | Description             |
+| --------------- | ---------------- | -------- | ----------------------- |
+| instrument_name | string           | Y        | e.g. BTCUSD-PERP        |
+| type            | string           | Y        | `LIMIT` or `MARKET`     |
+| price           | string           | Depends  | For `LIMIT` orders only |
+| quantity        | string of number | N        | Positive Number only    |
+
+Remark:  
+Only provide this field if intending to do partial closing |
 
 ### Applies To
 
@@ -2094,7 +2109,7 @@ POST
       "code": 0
     }
 
-Change the account STP settings.
+Change account level settings regarding STP and other properties.
 
 ### Request Params
 
@@ -2102,10 +2117,15 @@ Change the account STP settings.
 | --------- | ------ | -------- | -------------- |
 | stp_scope | string | N        | Optional Field |
 
-Possible Values  
+Possible Values:  
 M: Matches Master or Sub a/c  
-S: Matches Sub a/c only | | stp_inst | number | N | Mandatory if stp_scope is
-set.  
+S: Matches Sub a/c only  
+D: for resetting all STP fields to original default values.
+
+Remark:  
+Once 'D' is filled to 'stp_scope', inputs in 'stp_inst' and 'stp_id' fields in
+the same request will be ignored. | | stp_inst | number | N | Mandatory if
+stp_scope is set.  
 Possible Values  
 M: Cancel Maker  
 T: Cancel Taker  

--- a/docs/cryptocom/public_rest_api.md
+++ b/docs/cryptocom/public_rest_api.md
@@ -53,6 +53,16 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-07-17
+
+  - `private/fiat/fiat-deposit-info` was added
+  - `private/fiat/fiat-deposit-history` was added
+  - `private/fiat/fiat-withdraw-history` was added
+  - `private/fiat/fiat-create-withdraw` was added
+  - `private/fiat/fiat-get-bank-accounts` was added
+  - `private/fiat/fiat-transaction-quota` was added
+  - `private/fiat/fiat-transaction-limit` was added
+
 - 2025-07-04
 
   - `private/create-order` exec_inst was added `SMART_POST_ONLY`

--- a/docs/cryptocom/websocket_api.md
+++ b/docs/cryptocom/websocket_api.md
@@ -53,6 +53,16 @@ _Notes on Exchange Upgrade and API Versions_
 
 ## Change Logs
 
+- 2025-07-17
+
+  - `private/fiat/fiat-deposit-info` was added
+  - `private/fiat/fiat-deposit-history` was added
+  - `private/fiat/fiat-withdraw-history` was added
+  - `private/fiat/fiat-create-withdraw` was added
+  - `private/fiat/fiat-get-bank-accounts` was added
+  - `private/fiat/fiat-transaction-quota` was added
+  - `private/fiat/fiat-transaction-limit` was added
+
 - 2025-07-04
 
   - `private/create-order` exec_inst was added `SMART_POST_ONLY`


### PR DESCRIPTION
**PR Summary: Cryptocurrency Exchange API Documentation Updates**

The following documentation changes were made across the Private REST API, Public REST API, and WebSocket API docs:

- **New Fiat Endpoints Added**
  - Documented the addition of the following private fiat-related endpoints:
    - `private/fiat/fiat-deposit-info`
    - `private/fiat/fiat-deposit-history`
    - `private/fiat/fiat-withdraw-history`
    - `private/fiat/fiat-create-withdraw`
    - `private/fiat/fiat-get-bank-accounts`
    - `private/fiat/fiat-transaction-quota`
    - `private/fiat/fiat-transaction-limit`
  - These changes are reflected in the change logs of all three API documentation files.

- **Parameter and Documentation Updates**
  - **private/create-order endpoint:**
    - Added an optional `quantity` parameter (string of number, positive only) to the request parameters.
    - Clarified that `quantity` should only be provided for partial closing.
    - Updated example request payload to include the new `quantity` field.
  - **Account STP Settings:**
    - Expanded the description to clarify that the endpoint changes account-level settings for STP and other properties.
    - Added a new possible value `D` for the `stp_scope` parameter, allowing users to reset all STP fields to their original default values.
    - Added a remark specifying that when `D` is used, `stp_inst` and `stp_id` fields in the same request are ignored.
    - Improved formatting and clarity of possible values for `stp_scope` and `stp_inst`.

These updates improve the completeness and clarity of the API documentation, particularly regarding new fiat endpoints and enhanced parameter descriptions.