### PR TITLE
Bitmart API Documentation Update

### DIFF
--- a/docs/bitmart/futures/change_log.md
+++ b/docs/bitmart/futures/change_log.md
@@ -1,5 +1,14 @@
 # Change Log
 
+#### 2025-09-23
+
+###### REST API
+
+*   \[Update\] `/contract/private/trades` Get Order Trade
+    *   Request field **symbol** changed to optional
+
+* * *
+
 #### 2025-08-11
 
 ###### REST API

--- a/docs/bitmart/futures/futures_trading.md
+++ b/docs/bitmart/futures/futures_trading.md
@@ -455,7 +455,7 @@ See [Detailed Rate Limit](#rate-limit)
 
 | Field | Type | Required? | Description |
 | --- | --- | --- | --- |
-| symbol | String | Yes | Symbol of the contract(like BTCUSDT) 
+| symbol | String | No | Symbol of the contract(like BTCUSDT) 
 | account | String | No | Trading account<br>-<code>futures</code><br>-<code>copy_trading</code> 
 | start_time | Long | No | Start time(Timestamp in Seconds) 
 | end_time | Long | No | End time(Timestamp in Seconds) 


### PR DESCRIPTION
- Files changed
  - docs/bitmart/futures/futures_trading.md
  - docs/bitmart/futures/change_log.md

- What changed
  - Updated the Get Order Trade endpoint (/contract/private/trades):
    - The request field "symbol" is no longer required — documentation updated from "Required: Yes" to "Required: No" in the parameter table.
  - Added a changelog entry (2025-09-23) documenting the above REST API change.

- Type of change
  - Parameter requirement relaxed (symbol → optional)
  - Documentation update (parameter table and changelog entry)

- Notes / impact
  - Consumers of the API can omit the symbol parameter when calling /contract/private/trades; SDKs or integrations that currently enforce a required symbol should be updated accordingly.