### PR TITLE
Binance COINM API Documentation Update

### DIFF
--- a/docs/binance/coinm/public_websocket_api.md
+++ b/docs/binance/coinm/public_websocket_api.md
@@ -2059,8 +2059,13 @@ milliseconds
     **[https://dapi.binance.com/dapi/v1/depth?symbol=BTCUSD_200925&limit=1000](https://dapi.binance.com/dapi/v1/depth?symbol=BTCUSD_200925&limit=1000)**
     .
 4.  Drop any event where `u` is < `lastUpdateId` in the snapshot
-5.  The first processed event should have `U` `<=` lastUpdateId`**AND**`u `>`\=
-    `lastUpdateId`
+5.  The first processed event should have `U` `<= ``lastUpdateId` **AND**
+    `u` >`= ``lastUpdateId`
+
+- U = firstUpdateId (the first update ID) from the WebSocket stream.
+- u = finalUpdateId (the last update ID) from the WebSocket stream.
+- lastUpdateId = the update ID you got from the REST depth snapshot.
+
 6.  While listening to the stream, each new event's `pu` should be equal to the
     previous event's `u`, otherwise initialize the process from step 3.
 7.  The data in each event is the **absolute** quantity for a price level


### PR DESCRIPTION
- Files changed
  - docs/binance/coinm/public_websocket_api.md

- Summary of changes
  - Clarified the order-book synchronization steps for the coin-margined public WebSocket (depth) stream.
  - Fixed formatting/typo in step 5 so the requirement reads clearly: the first processed WebSocket event must satisfy U <= lastUpdateId AND u >= lastUpdateId.
  - Added explicit definitions for the update ID fields used in the sync logic:
    - U = firstUpdateId (first update ID from the WebSocket stream)
    - u = finalUpdateId (last update ID from the WebSocket stream)
    - lastUpdateId = update ID from the REST depth snapshot
  - Minor backtick/markdown cleanup to improve readability.

- Impact
  - Documentation-only change: no API endpoints or parameters were added/removed.
  - Improves clarity for implementers syncing REST depth snapshots with WebSocket depth updates, reducing ambiguity around update ID comparisons.