### PR TITLE
Binance Options API Documentation Update

### DIFF
--- a/docs/binance/coinm/public_websocket_api.md
+++ b/docs/binance/coinm/public_websocket_api.md
@@ -2059,8 +2059,13 @@ milliseconds
     **[https://dapi.binance.com/dapi/v1/depth?symbol=BTCUSD_200925&limit=1000](https://dapi.binance.com/dapi/v1/depth?symbol=BTCUSD_200925&limit=1000)**
     .
 4.  Drop any event where `u` is < `lastUpdateId` in the snapshot
-5.  The first processed event should have `U` `<=` lastUpdateId`**AND**`u `>`\=
-    `lastUpdateId`
+5.  The first processed event should have `U` `<= ``lastUpdateId` **AND**
+    `u` >`= ``lastUpdateId`
+
+- U = firstUpdateId (the first update ID) from the WebSocket stream.
+- u = finalUpdateId (the last update ID) from the WebSocket stream.
+- lastUpdateId = the update ID you got from the REST depth snapshot.
+
 6.  While listening to the stream, each new event's `pu` should be equal to the
     previous event's `u`, otherwise initialize the process from step 3.
 7.  The data in each event is the **absolute** quantity for a price level

--- a/docs/binance/usdm/public_websocket_api.md
+++ b/docs/binance/usdm/public_websocket_api.md
@@ -2157,10 +2157,15 @@ Bids and asks, pushed every 250 milliseconds, 500 milliseconds, 100 milliseconds
     **[https://fapi.binance.com/fapi/v1/depth?symbol=BTCUSDT&limit=1000](https://fapi.binance.com/fapi/v1/depth?symbol=BTCUSDT&limit=1000)**
     .
 4.  Drop any event where `u` is < `lastUpdateId` in the snapshot.
-5.  The first processed event should have `U` `<=` lastUpdateId`**AND**`u `>`\=
-    `lastUpdateId`
+5.  The first processed event should have `U` `<= ``lastUpdateId` **AND**
+    `u` >`= ``lastUpdateId`
+
+- U = firstUpdateId (the first update ID) from the WebSocket stream.
+- u = finalUpdateId (the last update ID) from the WebSocket stream.
+- lastUpdateId = the update ID you got from the REST depth snapshot.
+
 6.  While listening to the stream, each new event's `pu` should be equal to the
-    previous event's `u`, otherwise initialize the process from step 3.
+    previous event's `u`, otherwise initialize the process from step 3.ß
 7.  The data in each event is the **absolute** quantity for a price level.
 8.  If the quantity is 0, **remove** the price level.
 9.  Receiving an event that removes a price level that is not in your local


### PR DESCRIPTION
- Updated files
  - docs/binance/coinm/public_websocket_api.md
  - docs/binance/usdm/public_websocket_api.md

- Sections changed
  - Order book / depth WebSocket synchronization steps (the checklist describing how to sync a local order book with the REST snapshot + WebSocket depth stream). Changes appear around “step 5” (first processed event condition) and the following steps.

- What changed
  - Fixed formatting and clarified the conditional in step 5: the requirement for the first processed event now clearly reads that U <= lastUpdateId AND u >= lastUpdateId.
  - Added explicit definitions for the fields used in the synchronization logic:
    - U = firstUpdateId (first update ID from the WebSocket stream)
    - u = finalUpdateId (last update ID from the WebSocket stream)
    - lastUpdateId = the update ID from the REST depth snapshot
  - Minor punctuation/formatting cleanup in the surrounding steps for clarity.

- Notes / impact
  - These are documentation clarifications only — no API endpoints or parameters were added or changed.
  - The clarifications make the depth synchronization algorithm easier to understand and implement.
  - One minor unintended character (a stray non-ASCII character “ß”) appears at the end of a line in the USDM file and may need removal.